### PR TITLE
feat: Add WebSocket Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,7 @@ You can create and build an ensemble that way:
 
 ```csharp
 MicrocksContainersEnsemble ensemble = new MicrocksContainerEnsemble(network, MicrocksImage)
-    .WithMainArtifacts("pastry-orders-asyncapi.yml")
-    .WithKafkaConnection(new KafkaConnection($"kafka:19092"));
+    .WithMainArtifacts("pastry-orders-asyncapi.yml");
 
 ensemble.StartAsync();
 ```
@@ -176,15 +175,44 @@ You have to access it using:
 MicrocksContainer microcks = ensemble.MicrocksContainer;
 microcks.ImportAsMainArtifact(...);
 ```
+
+To activate async features (WebSocket), you can use `WithAsyncFeature()` method.
+
+```csharp
+MicrocksContainersEnsemble ensemble = new MicrocksContainerEnsemble(network, MicrocksImage)
+    .WithMainArtifacts("pastry-orders-asyncapi.yml")
+    .WithAsyncFeature();
+
+ensemble.StartAsync();
+```
+
+#### Asynchronous API support
+Asynchronous API feature needs to be explicitly enabled as well.
+In case you want to use it for mocking purposes,
+you'll have to specify additional connection details to the broker of your choice.
+
+To add a note indicating that it is not necessary to call `WithAsyncFeature()` when an additional method exists.
+
+See an example below with connection to a Kafka broker:
+
+```csharp
+MicrocksContainersEnsemble ensemble = new MicrocksContainerEnsemble(network, MicrocksImage)
+    .WithMainArtifacts("pastry-orders-asyncapi.yml")
+    .WithKafkaConnection(new KafkaConnection($"kafka:19092"));
+
+ensemble.StartAsync();
+```
+
 ##### Using mock endpoints for your dependencies
 
 Once started, the `ensemble.AsyncMinionContainer` provides methods for retrieving mock endpoint names for the different
-supported protocols (Kafka only at the moment).
+supported protocols (WebSocket, Kafka, etc. ...).
 
 ```csharp
 string kafkaTopic = ensemble.AsyncMinionContainer
     .GetKafkaMockTopic("Pastry orders API", "0.1.0", "SUBSCRIBE pastry/orders");
 ```
+
 ##### Launching new contract-tests
 
 Using contract-testing techniques on Asynchronous endpoints may require a different style of interacting with the Microcks

--- a/src/Microcks.Testcontainers/MicrocksAsyncMinionBuilder.cs
+++ b/src/Microcks.Testcontainers/MicrocksAsyncMinionBuilder.cs
@@ -75,7 +75,7 @@ public sealed class MicrocksAsyncMinionBuilder
             .WithNetwork(this._network)
             .WithNetworkAliases("microcks-async-minion")
             .WithEnvironment("MICROCKS_HOST_PORT", "microcks:" + MicrocksBuilder.MicrocksHttpPort)
-            .WithExposedPort(MicrocksAsyncMinionHttpPort)
+            .WithPortBinding(MicrocksAsyncMinionHttpPort, true)
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(".*Profile prod activated\\..*"));
     }
 

--- a/src/Microcks.Testcontainers/MicrocksAsyncMinionContainer.cs
+++ b/src/Microcks.Testcontainers/MicrocksAsyncMinionContainer.cs
@@ -41,14 +41,39 @@ public sealed class MicrocksAsyncMinionContainer : DockerContainer
     /// <returns>A formatted Kafka mock topic name.</returns>
     public string GetKafkaMockTopic(string service, string version, string operationName)
     {
-        // operationName may start with SUBSCRIBE or PUBLISH.
-        if (operationName.Contains(' '))
-        {
-            operationName = operationName.Split(' ')[1];
-        }
+        operationName = ExtractOperationName(operationName);
+
         return String.Format(DestinationPattern,
             service.Replace(" ", "").Replace("-", ""),
             version,
             operationName.Replace("/", "-"));
+    }
+
+    /// <summary>
+    /// Returns the WebSocket mock endpoint based on the provided service, version, and operation name.
+    /// </summary>
+    /// <returns>The WebSocket mock endpoint.</returns>
+    public Uri GetWebSocketMockEndpoint(string service, string version, string operationName)
+    {
+        operationName = ExtractOperationName(operationName);
+        var port = this.GetMappedPublicPort(MicrocksAsyncMinionBuilder.MicrocksAsyncMinionHttpPort);
+        var escapedService = service.Replace(" ", "+");
+        var escapedVersion = version.Replace(" ", "+");
+
+        return new Uri($"ws://{this.Hostname}:{port}/api/ws/{escapedService}/{escapedVersion}/{operationName}");
+    }
+
+    /// <summary>
+    /// Extracts the operation name from the provided operation name.
+    /// </summary>
+    /// <param name="operationName">operationName may start with SUBSCRIBE or PUBLISH.</param>
+    /// <returns>The extracted operation name.</returns>
+    private string ExtractOperationName(string operationName)
+    {
+        if (operationName.Contains(' '))
+        {
+            operationName = operationName.Split(' ')[1];
+        }
+        return operationName;
     }
 }

--- a/src/Microcks.Testcontainers/MicrocksContainer.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainer.cs
@@ -122,4 +122,5 @@ public sealed class MicrocksContainer : DockerContainer
     {
         return base.DisposeAsyncCore();
     }
+
 }

--- a/src/Microcks.Testcontainers/MicrocksContainerEnsemble.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainerEnsemble.cs
@@ -43,6 +43,9 @@ public class MicrocksContainerEnsemble : IAsyncDisposable
 
     private readonly INetwork _network;
 
+    public INetwork Network { get => this._network; }
+
+
     private readonly string _microcksImage;
 
     /// <summary>

--- a/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
@@ -15,7 +15,15 @@
 //
 //
 
+using System;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
 using FluentAssertions;
+using Microcks.Testcontainers.Model;
 
 namespace Microcks.Testcontainers.Tests.Async;
 
@@ -26,19 +34,51 @@ public sealed class MicrocksAsyncFeatureTest : IAsyncLifetime
     /// </summary>
     private const string MicrocksImage = "quay.io/microcks/microcks-uber:1.10.1-native";
 
+    private const string BadPastryAsyncImage = "quay.io/microcks/contract-testing-demo-async:01";
+    private const string GoodPastryAsyncImage = "quay.io/microcks/contract-testing-demo-async:02";
+
     private MicrocksContainerEnsemble _microcksContainerEnsemble;
+    private IContainer _wsGoodImplContainer;
+    private IContainer _wsBadImplContainer;
 
     public async Task DisposeAsync()
     {
         await this._microcksContainerEnsemble.DisposeAsync();
+        await this._wsBadImplContainer.DisposeAsync();
+        await this._wsGoodImplContainer.DisposeAsync();
     }
 
     public async Task InitializeAsync()
     {
         this._microcksContainerEnsemble = new MicrocksContainerEnsemble(MicrocksImage)
+            .WithMainArtifacts("pastry-orders-asyncapi.yml")
             .WithAsyncFeature();
 
+        this._wsBadImplContainer = new ContainerBuilder()
+            .WithImage(BadPastryAsyncImage)
+            .WithNetwork(this._microcksContainerEnsemble.Network)
+            .WithNetworkAliases("bad-impl")
+            .WithExposedPort(4001)
+            .WithWaitStrategy(
+                Wait.ForUnixContainer()
+                    .UntilMessageIsLogged(".*Starting WebSocket server on ws://localhost:4001/websocket.*")
+            )
+            .Build();
+
+        this._wsGoodImplContainer = new ContainerBuilder()
+            .WithImage(GoodPastryAsyncImage)
+            .WithNetwork(this._microcksContainerEnsemble.Network)
+            .WithNetworkAliases("good-impl")
+            .WithExposedPort(4002)
+            .WithWaitStrategy(
+                Wait.ForUnixContainer()
+                    .UntilMessageIsLogged(".*Starting WebSocket server on ws://localhost:4002/websocket.*")
+            )
+            .Build();
+
         await this._microcksContainerEnsemble.StartAsync();
+        await this._wsBadImplContainer.StartAsync();
+        await this._wsGoodImplContainer.StartAsync();
     }
 
     [Fact]
@@ -49,4 +89,92 @@ public sealed class MicrocksAsyncFeatureTest : IAsyncLifetime
             .Be("quay.io/microcks/microcks-uber-async-minion:1.10.1");
     }
 
+    /// <summary>
+    /// Test method to verify that a WebSocket message is received when a message is emitted.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task ShouldReceivedWebSocketMessageWhenMessageIsEmitted()
+    {
+        // Get the WebSocket endpoint for the "Pastry orders API" with version "0.1.0" and subscription "SUBSCRIBE pastry/orders".
+        var webSocketEndpoint = _microcksContainerEnsemble
+            .AsyncMinionContainer
+            .GetWebSocketMockEndpoint("Pastry orders API" ,"0.1.0", "SUBSCRIBE pastry/orders");
+        const string expectedMessage = "{\"id\":\"4dab240d-7847-4e25-8ef3-1530687650c8\",\"customerId\":\"fe1088b3-9f30-4dc1-a93d-7b74f0a072b9\",\"status\":\"VALIDATED\",\"productQuantities\":[{\"quantity\":2,\"pastryName\":\"Croissant\"},{\"quantity\":1,\"pastryName\":\"Millefeuille\"}]}";
+
+        using var webSocketClient = new ClientWebSocket();
+        await webSocketClient.ConnectAsync(webSocketEndpoint, CancellationToken.None);
+
+        var buffer = new byte[1024];
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(7));
+        var result = await webSocketClient.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
+        var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
+
+        await webSocketClient.CloseAsync(
+            WebSocketCloseStatus.NormalClosure,
+            "Test done",
+            CancellationToken.None);
+
+        message.Should().Be(expectedMessage);
+    }
+
+    /// <summary>
+    /// Test that verifies the correct status contract when a bad message is emitted.
+    /// </summary>
+    [Fact]
+    public async Task ShouldReturnsCorrectStatusContractWhenBadMessageIsEmitted()
+    {
+        // New Test request
+        var testRequest = new TestRequest
+        {
+            ServiceId = "Pastry orders API:0.1.0",
+            RunnerType = TestRunnerType.ASYNC_API_SCHEMA,
+            Timeout = TimeSpan.FromMilliseconds(70000),
+            TestEndpoint = "ws://bad-impl:4001/websocket",
+        };
+
+        var taskTestResult = _microcksContainerEnsemble.MicrocksContainer
+            .TestEndpointAsync(testRequest);
+
+        var testResult = await taskTestResult;
+
+        // Assert
+        testResult.InProgress.Should().Be(false);
+        testResult.Success.Should().Be(false);
+        testResult.TestedEndpoint.Should().Be(testRequest.TestEndpoint);
+
+        testResult.TestCaseResults.First().TestStepResults.Should().NotBeEmpty();
+        var testStepResult = testResult.TestCaseResults.First().TestStepResults.First();
+        testStepResult.Message.Should().Contain("object has missing required properties ([\"status\"]");
+    }
+
+    /// <summary>
+    /// Test that verifies the correct status contract when a good message is emitted.
+    /// </summary>
+    [Fact]
+    public async Task ShouldReturnsCorrectStatusContractWhenGoodMessageIsEmitted()
+    {
+        // New Test request
+        var testRequest = new TestRequest
+        {
+            ServiceId = "Pastry orders API:0.1.0",
+            RunnerType = TestRunnerType.ASYNC_API_SCHEMA,
+            Timeout = TimeSpan.FromMilliseconds(7000),
+            TestEndpoint = "ws://good-impl:4002/websocket",
+        };
+
+        var taskTestResult = _microcksContainerEnsemble.MicrocksContainer
+            .TestEndpointAsync(testRequest);
+
+        var testResult = await taskTestResult;
+
+        // Assert
+        testResult.InProgress.Should().Be(false);
+        testResult.Success.Should().Be(true);
+        testResult.TestedEndpoint.Should().Be(testRequest.TestEndpoint);
+
+        testResult.TestCaseResults.First().TestStepResults.Should().NotBeEmpty();
+        testResult.TestCaseResults.First().TestStepResults.First().Message.Should().BeNullOrEmpty();
+    }
 }


### PR DESCRIPTION
# Pull Request

## Proposed Changes

This pull request adds support for the WebSocket protocol to the application. The changes include the addition of WebSocket containers for both good and bad implementations in the MicrocksAsyncFeatureTest class. This will allow for testing WebSocket-based asynchronous features.

Additionally, the `MicrocksAsyncMinionBuilder` class has been updated to replace `.WithExposedPort(MicrocksAsyncMinionHttpPort)` with `.WithPortBinding(MicrocksAsyncMinionHttpPort, true)` to properly bind the ports for the WebSocket connections.

PR: https://github.com/microcks/microcks-testcontainers-dotnet/issues/20

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [x] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [x] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
