### PR TITLE
refactor: remove Fluent Assertions from unit tests

### DIFF
--- a/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
@@ -22,7 +22,6 @@ using System.Text;
 using System.Threading;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
-using FluentAssertions;
 using Microcks.Testcontainers.Model;
 
 namespace Microcks.Testcontainers.Tests.Async;
@@ -84,9 +83,8 @@ public sealed class MicrocksAsyncFeatureTest : IAsyncLifetime
     [Fact]
     public void ShouldDetermineCorrectImageMessage()
     {
-        this._microcksContainerEnsemble.AsyncMinionContainer.Image.FullName
-            .Should()
-            .Be("quay.io/microcks/microcks-uber-async-minion:1.10.1");
+        Assert.Equal("quay.io/microcks/microcks-uber-async-minion:1.10.1",
+            this._microcksContainerEnsemble.AsyncMinionContainer.Image.FullName);
     }
 
     /// <summary>
@@ -116,7 +114,7 @@ public sealed class MicrocksAsyncFeatureTest : IAsyncLifetime
             "Test done",
             CancellationToken.None);
 
-        message.Should().Be(expectedMessage);
+        Assert.Equal(expectedMessage, message);
     }
 
     /// <summary>
@@ -140,13 +138,13 @@ public sealed class MicrocksAsyncFeatureTest : IAsyncLifetime
         var testResult = await taskTestResult;
 
         // Assert
-        testResult.InProgress.Should().Be(false);
-        testResult.Success.Should().Be(false);
-        testResult.TestedEndpoint.Should().Be(testRequest.TestEndpoint);
+        Assert.False(testResult.InProgress);
+        Assert.False(testResult.Success);
+        Assert.Equal(testRequest.TestEndpoint, testResult.TestedEndpoint);
 
-        testResult.TestCaseResults.First().TestStepResults.Should().NotBeEmpty();
+        Assert.NotEmpty(testResult.TestCaseResults.First().TestStepResults);
         var testStepResult = testResult.TestCaseResults.First().TestStepResults.First();
-        testStepResult.Message.Should().Contain("object has missing required properties ([\"status\"]");
+        Assert.Contains("object has missing required properties ([\"status\"]", testStepResult.Message);
     }
 
     /// <summary>
@@ -170,11 +168,11 @@ public sealed class MicrocksAsyncFeatureTest : IAsyncLifetime
         var testResult = await taskTestResult;
 
         // Assert
-        testResult.InProgress.Should().Be(false);
-        testResult.Success.Should().Be(true);
-        testResult.TestedEndpoint.Should().Be(testRequest.TestEndpoint);
+        Assert.False(testResult.InProgress);
+        Assert.True(testResult.Success);
+        Assert.Equal(testRequest.TestEndpoint, testResult.TestedEndpoint);
 
-        testResult.TestCaseResults.First().TestStepResults.Should().NotBeEmpty();
-        testResult.TestCaseResults.First().TestStepResults.First().Message.Should().BeNullOrEmpty();
+        Assert.NotEmpty(testResult.TestCaseResults.First().TestStepResults);
+        Assert.True(string.IsNullOrEmpty(testResult.TestCaseResults.First().TestStepResults.First().Message));
     }
 }

--- a/tests/Microcks.Testcontainers.Tests/Microcks.Testcontainers.Tests.csproj
+++ b/tests/Microcks.Testcontainers.Tests/Microcks.Testcontainers.Tests.csproj
@@ -6,7 +6,6 @@
 	<NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="RestAssured.Net" Version="4.5.1" />

--- a/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0 
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,6 @@
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
-using FluentAssertions;
 using Microcks.Testcontainers;
 using Microcks.Testcontainers.Model;
 using System;
@@ -109,10 +108,10 @@ public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
 
         // First test should fail with validation failure messages.
         TestResult badTestResult = await _microcksContainer.TestEndpointAsync(badTestRequest);
-        badTestResult.Success.Should().BeFalse();
-        badTestResult.TestedEndpoint.Should().Be("http://bad-impl:3001");
-        badTestResult.TestCaseResults.Should().HaveCount(3);
-        badTestResult.TestCaseResults[0].TestStepResults[0].Message.Should().Contain("object has missing required properties");
+        Assert.False(badTestResult.Success);
+        Assert.Equal("http://bad-impl:3001", badTestResult.TestedEndpoint);
+        Assert.Equal(3, badTestResult.TestCaseResults.Count);
+        Assert.Contains("object has missing required properties", badTestResult.TestCaseResults[0].TestStepResults[0].Message);
 
         // Switch endpoint to good implementation
         var goodTestRequest = new TestRequest
@@ -123,10 +122,10 @@ public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
             Timeout = TimeSpan.FromMilliseconds(2000)
         };
         TestResult goodTestResult = await _microcksContainer.TestEndpointAsync(goodTestRequest);
-        goodTestResult.Success.Should().BeTrue();
-        goodTestResult.TestedEndpoint.Should().Be("http://good-impl:3002");
-        goodTestResult.TestCaseResults.Should().HaveCount(3);
-        goodTestResult.TestCaseResults[0].TestStepResults[0].Message.Should().BeEmpty();
+        Assert.True(goodTestResult.Success);
+        Assert.Equal("http://good-impl:3002", goodTestResult.TestedEndpoint);
+        Assert.Equal(3, goodTestResult.TestCaseResults.Count);
+        Assert.Empty(goodTestResult.TestCaseResults[0].TestStepResults[0].Message);
 
         // Test avec un header
         var goodTestRequestWithHeader = new TestRequest
@@ -151,15 +150,22 @@ public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
         };
 
         TestResult goodTestResultWithHeader = await _microcksContainer.TestEndpointAsync(goodTestRequestWithHeader);
-        goodTestResultWithHeader.Success.Should().BeTrue();
-        goodTestResultWithHeader.TestedEndpoint.Should().Be("http://good-impl:3002");
-        goodTestResultWithHeader.TestCaseResults.Should().HaveCount(3);
-        goodTestResultWithHeader.TestCaseResults[0].TestStepResults[0].Message.Should().BeEmpty();
-        goodTestResultWithHeader.OperationsHeaders.Should().HaveCount(1);
-        goodTestResultWithHeader.OperationsHeaders.Should().ContainKey("GET /pastries");
-        goodTestResultWithHeader.OperationsHeaders["GET /pastries"].Should().HaveCount(1);
+        Assert.True(goodTestResultWithHeader.Success);
+        Assert.Equal("http://good-impl:3002", goodTestResultWithHeader.TestedEndpoint);
+        Assert.Equal(3, goodTestResultWithHeader.TestCaseResults.Count);
+        Assert.Empty(goodTestResultWithHeader.TestCaseResults[0].TestStepResults[0].Message);
+        Assert.Single(goodTestResultWithHeader.OperationsHeaders);
+        Assert.True(goodTestResultWithHeader.OperationsHeaders.ContainsKey("GET /pastries"));
+        Assert.Single(goodTestResultWithHeader.OperationsHeaders["GET /pastries"]);
         var header = goodTestResultWithHeader.OperationsHeaders["GET /pastries"][0];
-        header.Name.Should().Be("X-Custom-Header-1");
-        header.Values.Split(",").Should().BeEquivalentTo(["value1", "value2", "value3"]);
+        Assert.Equal("X-Custom-Header-1", header.Name);
+
+        var actualItems = header.Values.Split(",");
+        var expectedItems = new[] { "value1", "value2", "value3" };
+
+        foreach (var expectedItem in expectedItems)
+        {
+            Assert.Contains(expectedItem, actualItems);
+        }
     }
 }

--- a/tests/Microcks.Testcontainers.Tests/MicrocksMockingFunctionalityTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksMockingFunctionalityTest.cs
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0 
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@
 //
 //
 
-using FluentAssertions;
 using NHamcrest;
 using NHamcrest.Core;
 using RestAssured.Logging;
@@ -50,16 +49,16 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
     public void ShouldConfigureMockEndpoints()
     {
         string baseWsUrl = $"{_microcksContainer.GetSoapMockEndpoint("Pastries Service", "1.0")}";
-        baseWsUrl.Should().Be($"{_microcksContainer.GetHttpEndpoint()}soap/Pastries Service/1.0");
+        Assert.Equal($"{_microcksContainer.GetHttpEndpoint()}soap/Pastries Service/1.0", baseWsUrl);
 
         string baseApiUrl = $"{_microcksContainer.GetRestMockEndpoint("API Pastries", "0.0.1")}";
-        baseApiUrl.Should().Be($"{_microcksContainer.GetHttpEndpoint()}rest/API Pastries/0.0.1");
+        Assert.Equal($"{_microcksContainer.GetHttpEndpoint()}rest/API Pastries/0.0.1", baseApiUrl);
 
         string baseGraphUrl = $"{_microcksContainer.GetGraphQLMockEndpoint("Pastries Graph", "1")}";
-        baseGraphUrl.Should().Be($"{_microcksContainer.GetHttpEndpoint()}graphql/Pastries Graph/1");
+        Assert.Equal($"{_microcksContainer.GetHttpEndpoint()}graphql/Pastries Graph/1", baseGraphUrl);
 
         string baseGrpcUrl = $"{_microcksContainer.GetGrpcMockEndpoint()}";
-        baseGrpcUrl.Should().Be($"grpc://{_microcksContainer.Hostname}:{_microcksContainer.GetMappedPublicPort(MicrocksBuilder.MicrocksGrpcPort)}/");
+        Assert.Equal($"grpc://{_microcksContainer.Hostname}:{_microcksContainer.GetMappedPublicPort(MicrocksBuilder.MicrocksGrpcPort)}/", baseGrpcUrl);
     }
 
     [Fact]
@@ -98,8 +97,7 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
           .Response().Content.ReadAsStringAsync();
 
         var document = JsonDocument.Parse(services);
-        document.RootElement.EnumerateArray().Should().HaveCount(7);
-
+        Assert.Equal(7, document.RootElement.GetArrayLength());
 
         verifiableResponse.Body("$[0:].name", Has.Items(
             Is.EqualTo("Petstore API"),

--- a/tests/Microcks.Testcontainers.Tests/MicrocksSecretCreationTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksSecretCreationTests.cs
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0 
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@
 //
 //
 
-using FluentAssertions;
 using Microcks.Testcontainers;
 using NHamcrest;
 using System;
@@ -59,7 +58,7 @@ public sealed class MicrocksSecretCreationTests : IAsyncLifetime
           .Response().Content.ReadAsStringAsync();
 
         var document = JsonDocument.Parse(result);
-        document.RootElement.EnumerateArray().Should().HaveCount(1);
+        Assert.Equal(1, document.RootElement.GetArrayLength());
     }
 
     [Fact]
@@ -68,8 +67,9 @@ public sealed class MicrocksSecretCreationTests : IAsyncLifetime
         var secret = new SecretBuilder()
           .WithName("my-secret")
           .Build();
-        secret.Should().NotBeNull();
-        secret.Name.Should().Be("my-secret");
+
+        Assert.NotNull(secret);
+        Assert.Equal("my-secret", secret.Name);
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request
## Proposed Changes

- Updated all test methods to use Xunit's Assert class
- Removed package dependency 

resolves #32

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [x] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [ ] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
