### PR TITLE
fix: ensure network are started asynchronously in InitializeAsync

### DIFF
--- a/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
@@ -16,6 +16,7 @@
 //
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Text;
@@ -123,21 +124,25 @@ public sealed class MicrocksAsyncFeatureTest : IAsyncLifetime
     [Fact]
     public async Task ShouldReturnsCorrectStatusContractWhenBadMessageIsEmitted()
     {
+        var stopwatch = new Stopwatch();
         // New Test request
         var testRequest = new TestRequest
         {
             ServiceId = "Pastry orders API:0.1.0",
             RunnerType = TestRunnerType.ASYNC_API_SCHEMA,
-            Timeout = TimeSpan.FromMilliseconds(70000),
+            Timeout = TimeSpan.FromMilliseconds(70001),
             TestEndpoint = "ws://bad-impl:4001/websocket",
         };
 
         var taskTestResult = _microcksContainerEnsemble.MicrocksContainer
             .TestEndpointAsync(testRequest);
+        stopwatch.Start();
 
         var testResult = await taskTestResult;
+        stopwatch.Stop();
 
         // Assert
+        Assert.True(stopwatch.ElapsedMilliseconds > 70000);
         Assert.False(testResult.InProgress);
         Assert.False(testResult.Success);
         Assert.Equal(testRequest.TestEndpoint, testResult.TestedEndpoint);

--- a/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
@@ -74,6 +74,7 @@ public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
           (_, _) => _microcksContainer.ImportAsMainArtifact("apipastries-openapi.yaml");
 
         return Task.WhenAll(
+          _network.CreateAsync(),
           _microcksContainer.StartAsync(),
           _badImpl.StartAsync(),
           _goodImpl.StartAsync()

--- a/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityWithOAuth2Tests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityWithOAuth2Tests.cs
@@ -73,6 +73,7 @@ public sealed class MicrocksContractTestingFunctionalityWithOAuth2Tests : IAsync
           (_, _) => _microcksContainer.ImportAsMainArtifact("apipastries-openapi.yaml");
 
         return Task.WhenAll(
+          _network.CreateAsync(),
           _microcksContainer.StartAsync(),
           _keycloak.StartAsync(),
           _goodImpl.StartAsync()


### PR DESCRIPTION
# Pull Request

**fix:** ensure network creation in Initialize method to stabilize tests

## Proposed Changes

This fix addresses random test failures encountered when a network is used, caused by a missing network creation in the Initialize method of the `IAsyncLifetime` interface. Tests should now execute consistently without failures due to missing network.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request?
- [x] Run `dotnet test` and ensure you have test coverage for the lines you are introducing.
- [x] Run `dotnet husky run` and fix any issues that you have introduced.

### Reviewer

- [x] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance`, or `breaking`.