### PR TITLE
refactor: Rename test namespaces for consistency

### DIFF
--- a/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
@@ -24,7 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 
-namespace Testcontainers.Microcks.Tests;
+namespace Microcks.Testcontainers.Tests;
 
 public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
 {

--- a/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityWithOAuth2Tests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityWithOAuth2Tests.cs
@@ -24,7 +24,7 @@ using System;
 using System.Net;
 using Testcontainers.Keycloak;
 
-namespace Testcontainers.Microcks.Tests;
+namespace Microcks.Testcontainers.Tests;
 
 public sealed class MicrocksContractTestingFunctionalityWithOAuth2Tests : IAsyncLifetime
 {

--- a/tests/Microcks.Testcontainers.Tests/MicrocksSecretCreationTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksSecretCreationTests.cs
@@ -23,7 +23,7 @@ using System.Text.Json;
 using Microcks.Testcontainers.Model;
 using RestAssured.Logging;
 
-namespace Testcontainers.Microcks.Tests;
+namespace Microcks.Testcontainers.Tests;
 
 public sealed class MicrocksSecretCreationTests : IAsyncLifetime
 {


### PR DESCRIPTION
# Pull Request

fix: align test namespaces with source code structure

## Proposed Changes

- Updated test namespaces from `Testcontainers.Microcks.Tests` to `Microcks.Testcontainers.Tests` for consistency.
- Ensured alignment with .NET naming conventions and improved maintainability.
- Verified that all test cases execute successfully after the modifications.

This change addresses the issue where the test namespaces did not match the source code structure, enhancing code organization and readability.




