### PR TITLE
test: enhance MicrocksAsyncFeatureTest with logging and assertions

### DIFF
--- a/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
@@ -48,12 +48,14 @@ public static class MicrocksContainerExtensions
     });
 
     /// <summary>
-    /// Test an endpoint with a TestRequest.
+    /// Tests an endpoint with a given TestRequest by sending the request to the Microcks container
+    /// and polling for the test result until the test is completed or the timeout is reached.
     /// </summary>
-    /// <param name="container"></param>
-    /// <param name="testRequest"></param>
-    /// <returns></returns>
-    /// <exception cref="Exception"></exception>
+    /// <param name="container">The Microcks container to test against.</param>
+    /// <param name="testRequest">The TestRequest containing the details of the test to be performed.</param>
+    /// <returns>A Task representing the asynchronous operation, with a TestResult as the result.</returns>
+    /// <exception cref="Exception">Thrown if the test could not be launched
+    /// or if there was an error during the test execution.</exception>
     public static async Task<TestResult> TestEndpointAsync(
         this MicrocksContainer container, TestRequest testRequest)
     {
@@ -75,11 +77,12 @@ public static class MicrocksContainerExtensions
                     atMost: TimeSpan.FromMilliseconds(1000).Add(testRequest.Timeout),
                     delay: TimeSpan.FromMilliseconds(100),
                     interval: TimeSpan.FromMilliseconds(200));
-
             }
-            catch (TaskCanceledException)
+            catch (TaskCanceledException taskCanceledException)
             {
-                container.Logger.LogWarning("Test timeout reached, stopping polling");
+                container.Logger.LogWarning(
+                    taskCanceledException,
+                    "Test timeout reached, stopping polling for test {testEndpoint}", testRequest.TestEndpoint);
             }
 
             return await RefreshTestResultAsync(httpEndpoint, testResultId);

--- a/tests/Microcks.Testcontainers.Tests/WaitForConditionAsyncTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/WaitForConditionAsyncTests.cs
@@ -1,0 +1,101 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+using Microcks.Testcontainers.Model;
+using System;
+using System.Diagnostics;
+
+namespace Microcks.Testcontainers.Tests;
+
+/// <summary>
+/// This class contains tests for the WaitForConditionAsync method.
+/// </summary>
+public class WaitForConditionAsyncTests : IAsyncLifetime
+{
+    /// <summary>
+    /// Image name for the Microcks container.
+    /// </summary>
+    private const string MicrocksImage = "quay.io/microcks/microcks-uber:1.10.1-native";
+
+    private const string GoodPastryAsyncImage = "quay.io/microcks/contract-testing-demo-async:02";
+
+    private MicrocksContainerEnsemble _microcksContainerEnsemble;
+    private IContainer _wsGoodImplContainer;
+
+    public async Task InitializeAsync()
+    {
+        this._microcksContainerEnsemble = new MicrocksContainerEnsemble(MicrocksImage)
+            .WithMainArtifacts("pastry-orders-asyncapi.yml")
+            .WithAsyncFeature();
+
+        this._wsGoodImplContainer = new ContainerBuilder()
+            .WithImage(GoodPastryAsyncImage)
+            .WithNetwork(this._microcksContainerEnsemble.Network)
+            .WithNetworkAliases("good-impl")
+            .WithExposedPort(4002)
+            .WithWaitStrategy(
+                Wait.ForUnixContainer()
+                    .UntilMessageIsLogged(".*Starting WebSocket server on ws://localhost:4002/websocket.*")
+            )
+            .Build();
+
+        await this._microcksContainerEnsemble.StartAsync();
+        await this._wsGoodImplContainer.StartAsync();
+
+    }
+
+    public async Task DisposeAsync()
+    {
+        await this._microcksContainerEnsemble.DisposeAsync();
+        await this._wsGoodImplContainer.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Test that verifies that the WaitForConditionAsync method throws a TaskCanceledException
+    /// when the specified timeout is reached.
+    /// </summary>
+    [Fact]
+    public async Task WaitForConditionAsyncShouldThrowTaskCanceledExceptionWhenTimeoutIsReached()
+    {
+        // New Test request
+        var testRequest = new TestRequest
+        {
+            ServiceId = "Pastry orders API:0.1.0",
+            RunnerType = TestRunnerType.ASYNC_API_SCHEMA,
+            Timeout = TimeSpan.FromMilliseconds(200),
+            TestEndpoint = "ws://good-impl:4002/websocket",
+        };
+
+        var taskTestResult = _microcksContainerEnsemble.MicrocksContainer
+            .TestEndpointAsync(testRequest);
+
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+        var testResult = await taskTestResult;
+        stopwatch.Stop();
+
+        // Assert
+        Assert.True(stopwatch.ElapsedMilliseconds > 200);
+        Assert.True(testResult.InProgress);
+        Assert.False(testResult.Success);
+        Assert.Equal(testRequest.TestEndpoint, testResult.TestedEndpoint);
+    }
+}
+


### PR DESCRIPTION
# Pull Request

The objective of this pull request is to add logging for better traceability of test results and to correct the timeout values in the test assertions. Previously, with a timeout of 70 seconds, the test results took longer to process, and the `InProgress` status remained true for an extended period. By fixing the timeout to 7 seconds, the tests now accurately reflect the expected behavior and complete in a timely manner.

Added handling for longer processing times to ensure tests complete correctly but a complementary analysis is required.

Issue: #44

## Proposed Changes

- Added logging to trace test results in `MicrocksAsyncFeatureTest.cs`.
- Fixed timeout value in test assertions to ensure accurate test results.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [x] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [x] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
