### PR TITLE
fix: Update JSON validation messages after Microcks update

### DIFF
--- a/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
@@ -112,7 +112,7 @@ public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
         Assert.False(badTestResult.Success);
         Assert.Equal("http://bad-impl:3001", badTestResult.TestedEndpoint);
         Assert.Equal(3, badTestResult.TestCaseResults.Count);
-        Assert.Contains("object has missing required properties", badTestResult.TestCaseResults[0].TestStepResults[0].Message);
+        Assert.Contains("string found, number expected", badTestResult.TestCaseResults[0].TestStepResults[0].Message);
 
         // Switch endpoint to good implementation
         var goodTestRequest = new TestRequest


### PR DESCRIPTION
# Pull Request

Following Microcks `1.11.1` release last week, the `quay.io/microcks/microcks-uber:latest` image now has an updated JSON schema validation library that produces different and clearer messages. As our test ar checking the reason fo failures, they are now broken and we must update them (see https://github.com/microcks/microcks-testcontainers-dotnet/pull/49)

## Proposed Changes

Just fixes the messages string in the test(s)

## Readiness Checklist

### Author/Contributor

- [X] If documentation is needed for this change, has that been included in this pull request
- [X] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [X] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
