### PR TITLE
fix: resolve CODEOWNERS conflict for correct owner assignment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,4 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @SebastienDegodez
-* @lbroudoux
+* @SebastienDegodez @lbroudoux


### PR DESCRIPTION
# Pull Request
fix: resolve CODEOWNERS conflict for correct owner assignment

## Proposed Changes

This PR resolves a conflict in the `CODEOWNERS` file by ensuring the correct owner assignment for the affected directories. The issue was caused by the last rule in the file taking precedence over earlier ones, leading to incorrect owner assignments. The file has been reordered to ensure proper owner recognition for the relevant section.

No functional changes to the codebase were introduced, only a correction to the ownership rules.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [ ] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [ ] Label as either `feature`, `fix`, `documentation
