### PR TITLE
feat(amp): Add API to enable RabbitMQ support

### DIFF
--- a/src/Microcks.Testcontainers/Connection/GenericConnection.cs
+++ b/src/Microcks.Testcontainers/Connection/GenericConnection.cs
@@ -1,0 +1,32 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+namespace Microcks.Testcontainers.Connection;
+
+public class GenericConnection
+{
+    public string Url { get; }
+    public string Username { get; }
+    public string Password { get; }
+
+    public GenericConnection(string url, string username = null, string password = null)
+    {
+        Url = url;
+        Username = username;
+        Password = password;
+    }
+}

--- a/src/Microcks.Testcontainers/MicrocksAsyncMinionBuilder.cs
+++ b/src/Microcks.Testcontainers/MicrocksAsyncMinionBuilder.cs
@@ -114,4 +114,23 @@ public sealed class MicrocksAsyncMinionBuilder
 
         return Merge(DockerResourceConfiguration, new MicrocksAsyncMinionConfiguration(new ContainerConfiguration(environments: environments)));
     }
+
+    /// <summary>
+    /// Configures the MicrocksAsyncMinionBuilder to use an AMQP connection.
+    /// </summary>
+    /// <param name="amqpConnection">The AMQP connection details.</param>
+    /// <returns>The updated MicrocksAsyncMinionBuilder instance.</returns>
+    public MicrocksAsyncMinionBuilder WithAmqpConnection(GenericConnection amqpConnection)
+    {
+        _extraProtocols.Add("AMQP");
+        var environments = new Dictionary<string, string>
+        {
+            { "ASYNC_PROTOCOLS", $",{string.Join(",", _extraProtocols)}" },
+            { "AMQP_SERVER", amqpConnection.Url },
+            { "AMQP_USERNAME", amqpConnection.Username },
+            { "AMQP_PASSWORD", amqpConnection.Password },
+        };
+
+        return Merge(DockerResourceConfiguration, new MicrocksAsyncMinionConfiguration(new ContainerConfiguration(environments: environments)));
+    }
 }

--- a/src/Microcks.Testcontainers/MicrocksContainerEnsemble.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainerEnsemble.cs
@@ -138,6 +138,22 @@ public class MicrocksContainerEnsemble : IAsyncDisposable
     }
 
     /// <summary>
+    /// Configures the Microcks container ensemble with an AMQP connection.
+    /// </summary>
+    /// <param name="amqpConnection">The AMQP connection details.</param>
+    /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns>
+    public MicrocksContainerEnsemble WithAmqpConnection(GenericConnection amqpConnection)
+    {
+        // Ensure the asynchronous feature is enabled.
+        this.WithAsyncFeature();
+
+        this._asyncMinionBuilder = (_asyncMinionBuilder ?? throw new NullReferenceException("MicrocksAsyncMinionBuilder is null"))
+            .WithAmqpConnection(amqpConnection);
+
+        return this;
+    }
+
+    /// <summary>
     /// Starts the Microcks container ensemble asynchronously.
     /// </summary>
     public async Task StartAsync()

--- a/tests/Microcks.Testcontainers.Tests/Async/Amqp/MicrocksAsyncAmqpFeatureTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/Async/Amqp/MicrocksAsyncAmqpFeatureTest.cs
@@ -1,0 +1,109 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+using Testcontainers.RabbitMq;
+using DotNet.Testcontainers.Networks;
+using DotNet.Testcontainers.Builders;
+using System;
+using System.Threading;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Microcks.Testcontainers.Connection;
+
+namespace Microcks.Testcontainers.Tests.Async.Amqp;
+
+public class MicrocksAsyncAmqpFeatureTest : IAsyncLifetime
+{
+    private RabbitMqContainer _rabbitMqContainer;
+    private MicrocksContainerEnsemble _ensemble;
+    private INetwork _network;
+
+    public async Task InitializeAsync()
+    {
+        _network = new NetworkBuilder().Build();
+        _rabbitMqContainer = new RabbitMqBuilder()
+            .WithImage("rabbitmq:3.13-management-alpine")
+            .WithNetwork(_network)
+            .WithNetworkAliases("rabbitmq")
+            .Build();
+
+        await _rabbitMqContainer.StartAsync()
+            .ConfigureAwait(false);
+        await _rabbitMqContainer.ExecAsync(["rabbitmqctl", "add_user", "test", "test"]);
+        await _rabbitMqContainer.ExecAsync(["rabbitmqctl", "set_permissions", "-p", "/", "test", ".*", ".*", ".*"]);
+
+        _ensemble = new MicrocksContainerEnsemble(_network, "quay.io/microcks/microcks-uber")
+            .WithMainArtifacts("pastry-orders-asyncapi.yml")
+            .WithAsyncFeature()
+            .WithAmqpConnection(new GenericConnection("rabbitmq:5672", "test", "test"));
+        await _ensemble.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_ensemble != null)
+            await _ensemble.DisposeAsync();
+        if (_rabbitMqContainer != null)
+            await _rabbitMqContainer.DisposeAsync();
+        if (_network != null)
+            await _network.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ShouldReceiveAmqpMockMessageWhenMicrocksAsyncMinonEmits()
+    {
+        const string expectedMessage = "{\"id\":\"4dab240d-7847-4e25-8ef3-1530687650c8\",\"customerId\":\"fe1088b3-9f30-4dc1-a93d-7b74f0a072b9\",\"status\":\"VALIDATED\",\"productQuantities\":[{\"quantity\":2,\"pastryName\":\"Croissant\"},{\"quantity\":1,\"pastryName\":\"Millefeuille\"}]}";
+        // Construction du nom de la destination AMQP comme dans le test Kafka
+        var amqpDestination = "PastryordersAPI-0.1.0-pastry/orders";
+
+        var factory = new ConnectionFactory
+        {
+            HostName = _rabbitMqContainer.Hostname,
+            Port = _rabbitMqContainer.GetMappedPublicPort(5672),
+            UserName = "test",
+            Password = "test"
+        };
+
+        string receivedMessage = null;
+        using var connection = await factory.CreateConnectionAsync();
+        using var channel = await connection.CreateChannelAsync();
+
+        await channel.ExchangeDeclareAsync(amqpDestination, "topic", false);
+        var queueDeclareResult = await channel.QueueDeclareAsync();
+        var queueName = queueDeclareResult.QueueName;
+        await channel.QueueBindAsync(queueName, amqpDestination, "#");
+
+        var consumer = new AsyncEventingBasicConsumer(channel);
+        var messageReceived = new ManualResetEventSlim(false);
+
+        consumer.ReceivedAsync += async (model, ea) =>
+        {
+            receivedMessage = System.Text.Encoding.UTF8.GetString(ea.Body.ToArray());
+            await channel.BasicAckAsync(ea.DeliveryTag, false);
+            messageReceived.Set();
+        };
+
+        await channel.BasicConsumeAsync(queue: queueName, autoAck: false, consumer: consumer);
+
+        // Attendre le message (timeout 5s)
+        messageReceived.Wait(TimeSpan.FromSeconds(5));
+
+        Assert.NotNull(receivedMessage);
+        Assert.True(receivedMessage.Length > 1);
+        Assert.Equal(expectedMessage, receivedMessage);
+    }
+}

--- a/tests/Microcks.Testcontainers.Tests/Microcks.Testcontainers.Tests.csproj
+++ b/tests/Microcks.Testcontainers.Tests/Microcks.Testcontainers.Tests.csproj
@@ -8,10 +8,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageReference Include="RestAssured.Net" Version="4.6.0" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="TestContainers.Kafka" Version="4.4.0" />
     <PackageReference Include="TestContainers.Keycloak" Version="4.4.0" />
+    <PackageReference Include="Testcontainers.RabbitMq" Version="4.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.9.2" />
   </ItemGroup>


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Introduce AMQP connection support in Microcks components, enhancing the asynchronous protocol capabilities. This implementation includes a new `GenericConnection` class for connection details and methods in `MicrocksAsyncMinionBuilder` and `MicrocksContainerEnsemble` to configure AMQP connections. Additionally, a test class is added to validate message reception from the RabbitMQ container.

Fixes #21

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [x] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [ ] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
