### PR TITLE
feat: #23 Allow retrieving messages for a test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ public async Task testOpenAPIContract()
 
 The `TestResult` gives you access to all details regarding success of failure on different test cases.
 
+In addition, you can use the `GetMessagesForTestCaseAsync()` method to retrieve the messages exchanged during the test.
+
 **Important:** You must host the API on a port that is accessible from the Microcks container. If your tests are using WebApplicationFactory, the API is hosted on an in-memory server and does not expose a port.
 
 One way to do this is to specify a URL to the WebApplication. However, this requires not to use the minimal hosting model (Program.cs without Main and without Startup.cs).
@@ -296,3 +298,5 @@ Task<TestResult> testResultFuture = ensemble.MicrocksContainer.TestEndpointAsync
 TestResult testResult = await testResultFuture;
 testResult.IsSuccess.Should().BeTrue();
 ```
+
+In addition, you can use the `GetEventMessagesForTestCaseAsync()` method to retrieve the events received during the test.

--- a/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
@@ -183,6 +183,32 @@ public static class MicrocksContainerExtensions
     }
 
     /// <summary>
+    /// Retrieve messages exchanged during a test on an endpoint (for further investigation or checks).
+    /// </summary>
+    /// <param name="container">Microcks container</param>
+    /// <param name="testResult">The test result to retrieve messages from</param>
+    /// <param name="operationName">The name of the operation to retrieve messages to test result</param>
+    /// <returns>List of RequestResponsePair</returns>
+    /// <exception cref="MicrocksException">If messages have not been correctly retrieved</exception>
+    public static async Task<List<RequestResponsePair>> GetMessagesForTestCaseAsync(this MicrocksContainer container,
+        TestResult testResult, string operationName)
+    {
+        var operation = operationName.Replace('/', '!');
+        var testCaseId = $"{testResult.Id}-{testResult.TestNumber}-{HttpUtility.UrlEncode(operation)}";
+        var url = $"{container.GetHttpEndpoint()}api/tests/{testResult.Id}/messages/{testCaseId}";
+        var response = await Client.GetAsync(url);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            return await response.Content.ReadFromJsonAsync<List<RequestResponsePair>>();
+        }
+        else
+        {
+            throw new MicrocksException($"Couldn't retrieve messages for test case {operationName} on test {testResult.Id}");
+        }
+    }
+
+    /// <summary>
     /// Retrieve event messages received during a test on an endpoint (for further investigation or checks).
     /// </summary>
     /// <param name="container">Microcks container</param>

--- a/src/Microcks.Testcontainers/Model/Message.cs
+++ b/src/Microcks.Testcontainers/Model/Message.cs
@@ -1,0 +1,64 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+using System.Text.Json.Serialization;
+
+namespace Microcks.Testcontainers.Model;
+
+/// <summary>
+/// Domain object representing a microservice operation / action invocation response.
+/// </summary>
+public class Message
+{
+
+    /// <summary>
+    /// Name of the message.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Content of the message.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public string Content { get; set; }
+
+    /// <summary>
+    /// Operation ID of the message.
+    /// </summary>
+    [JsonPropertyName("operationId")]
+    public string OperationId { get; set; }
+
+    /// <summary>
+    /// Test case ID of the message.
+    /// </summary>
+    [JsonPropertyName("testCaseId")]
+    public string TestCaseId { get; set; }
+
+
+    /// <summary>
+    /// Source Artifact of the message.
+    /// </summary>
+    [JsonPropertyName("sourceArtifact")]
+    public string SourceArtifact { get; set; }
+
+    /// <summary>
+    /// Headers of the event message.
+    /// </summary>
+    [JsonPropertyName("headers")]
+    public List<Header> Headers { get; set; }
+}

--- a/src/Microcks.Testcontainers/Model/Message.cs
+++ b/src/Microcks.Testcontainers/Model/Message.cs
@@ -22,7 +22,7 @@ namespace Microcks.Testcontainers.Model;
 /// <summary>
 /// Domain object representing a microservice operation / action invocation response.
 /// </summary>
-public class Message
+public abstract class Message
 {
 
     /// <summary>

--- a/src/Microcks.Testcontainers/Model/Parameter.cs
+++ b/src/Microcks.Testcontainers/Model/Parameter.cs
@@ -20,26 +20,19 @@ using System.Text.Json.Serialization;
 namespace Microcks.Testcontainers.Model;
 
 /// <summary>
-/// Represents an event message with details such as name, content, test case ID, headers, ID, and media type.
+/// Companion objects for Request representing query parameter.
 /// </summary>
-public class EventMessage : Message
+public class Parameter
 {
-    
     /// <summary>
-    /// ID of the event message.
+    /// The name of the parameter.
     /// </summary>
-    [JsonPropertyName("id")]
-    public string Id { get; set; }
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
 
     /// <summary>
-    /// Media type of the event message.
+    /// The value of the parameter.
     /// </summary>
-    [JsonPropertyName("mediaType")]
-    public string MediaType { get; set; }
-
-    /// <summary>
-    /// Dispatch Criteria of the response.
-    /// </summary>
-    [JsonPropertyName("dispatchCriteria")]
-    public string DispatchCriteria { get; set; }
+    [JsonPropertyName("value")]
+    public string Value { get; set; }
 }

--- a/src/Microcks.Testcontainers/Model/Request.cs
+++ b/src/Microcks.Testcontainers/Model/Request.cs
@@ -20,26 +20,26 @@ using System.Text.Json.Serialization;
 namespace Microcks.Testcontainers.Model;
 
 /// <summary>
-/// Represents an event message with details such as name, content, test case ID, headers, ID, and media type.
+/// Domain object representing a Microservice operation / action invocation request.
 /// </summary>
-public class EventMessage : Message
+public class Request : Message
 {
-    
+
     /// <summary>
-    /// ID of the event message.
+    /// Gets or sets the id of the request.
     /// </summary>
     [JsonPropertyName("id")]
     public string Id { get; set; }
 
     /// <summary>
-    /// Media type of the event message.
+    /// Gets or sets the responseId of the request.
     /// </summary>
-    [JsonPropertyName("mediaType")]
-    public string MediaType { get; set; }
+    [JsonPropertyName("responseId")]
+    public string ResponseId { get; set; }
 
     /// <summary>
-    /// Dispatch Criteria of the response.
+    /// Gets or sets the queryParameters of the request.
     /// </summary>
-    [JsonPropertyName("dispatchCriteria")]
-    public string DispatchCriteria { get; set; }
+    [JsonPropertyName("queryParameters")]
+    public List<Parameter> QueryParameters { get; set; }
 }

--- a/src/Microcks.Testcontainers/Model/RequestResponsePair.cs
+++ b/src/Microcks.Testcontainers/Model/RequestResponsePair.cs
@@ -20,26 +20,26 @@ using System.Text.Json.Serialization;
 namespace Microcks.Testcontainers.Model;
 
 /// <summary>
-/// Represents an event message with details such as name, content, test case ID, headers, ID, and media type.
+/// Represents a request/response pair with associated messages.
 /// </summary>
-public class EventMessage : Message
+public class RequestResponsePair
 {
-    
-    /// <summary>
-    /// ID of the event message.
-    /// </summary>
-    [JsonPropertyName("id")]
-    public string Id { get; set; }
 
     /// <summary>
-    /// Media type of the event message.
+    /// Gets or sets the type of the exchange.
     /// </summary>
-    [JsonPropertyName("mediaType")]
-    public string MediaType { get; set; }
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
 
     /// <summary>
-    /// Dispatch Criteria of the response.
+    /// Gets or sets the request associated with the exchanges pair.
     /// </summary>
-    [JsonPropertyName("dispatchCriteria")]
-    public string DispatchCriteria { get; set; }
+    [JsonPropertyName("request")]
+    public Request Request { get; set; }
+
+    /// <summary>
+    /// Gets or sets the response associated with the exchanges pair.
+    /// </summary>
+    [JsonPropertyName("response")]
+    public Response Response { get; set; }
 }

--- a/src/Microcks.Testcontainers/Model/Response.cs
+++ b/src/Microcks.Testcontainers/Model/Response.cs
@@ -20,19 +20,25 @@ using System.Text.Json.Serialization;
 namespace Microcks.Testcontainers.Model;
 
 /// <summary>
-/// Represents an event message with details such as name, content, test case ID, headers, ID, and media type.
+/// Domain object representing a microservice operation / action invocation response.
 /// </summary>
-public class EventMessage : Message
+public class Response : Message
 {
-    
+
     /// <summary>
-    /// ID of the event message.
+    /// Id of the response.
     /// </summary>
     [JsonPropertyName("id")]
     public string Id { get; set; }
 
     /// <summary>
-    /// Media type of the event message.
+    /// Status of the response.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public string Status { get; set; }
+
+    /// <summary>
+    /// Media type of the response.
     /// </summary>
     [JsonPropertyName("mediaType")]
     public string MediaType { get; set; }

--- a/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
@@ -114,6 +114,20 @@ public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
         Assert.Equal(3, badTestResult.TestCaseResults.Count);
         Assert.Contains("string found, number expected", badTestResult.TestCaseResults[0].TestStepResults[0].Message);
 
+        // Retrieve messages for the failing test case.
+        List<RequestResponsePair> messages = await _microcksContainer.GetMessagesForTestCaseAsync(badTestResult, "GET /pastries");
+        Assert.Equal(3, messages.Count);
+        for (int i = 0; i < messages.Count; i++)
+        {
+            Assert.NotNull(messages[i].Request);
+            Assert.NotNull(messages[i].Response);
+            Assert.NotNull(messages[i].Response.Content);
+            // Check these are the correct requests.
+            Assert.NotNull(messages[i].Request.QueryParameters);
+            Assert.Single(messages[i].Request.QueryParameters);
+            Assert.Equal("size", messages[i].Request.QueryParameters[0].Name);
+        }
+
         // Switch endpoint to good implementation
         var goodTestRequest = new TestRequest
         {

--- a/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
@@ -117,16 +117,16 @@ public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
         // Retrieve messages for the failing test case.
         List<RequestResponsePair> messages = await _microcksContainer.GetMessagesForTestCaseAsync(badTestResult, "GET /pastries");
         Assert.Equal(3, messages.Count);
-        for (int i = 0; i < messages.Count; i++)
+        Assert.All(messages, message =>
         {
-            Assert.NotNull(messages[i].Request);
-            Assert.NotNull(messages[i].Response);
-            Assert.NotNull(messages[i].Response.Content);
-            // Check these are the correct requests.
-            Assert.NotNull(messages[i].Request.QueryParameters);
-            Assert.Single(messages[i].Request.QueryParameters);
-            Assert.Equal("size", messages[i].Request.QueryParameters[0].Name);
-        }
+          Assert.NotNull(message.Request);
+          Assert.NotNull(message.Response);
+          Assert.NotNull(message.Response.Content);
+          // Check these are the correct requests.
+          Assert.NotNull(message.Request.QueryParameters);
+          Assert.Single(message.Request.QueryParameters);
+          Assert.Equal("size", message.Request.QueryParameters[0].Name);
+        });
 
         // Switch endpoint to good implementation
         var goodTestRequest = new TestRequest


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Provides a new `public static async Task<List<RequestResponsePair>> GetMessagesForTestCaseAsync(this MicrocksContainer container, TestResult testResult, string operationName)` function on `MicrocksContainerExtensions` to address #23 

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [X] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [X] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [ ] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
