### PR TITLE
feat: #24 Allow verifying invocation and get invocation count

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ The container provides methods for different supported API styles/protocols (Soa
 
 The container also provides `GetHttpEndpoint()` for raw access to those API endpoints.
 
+### Verifying mock endpoint has been invoked
+
+Once the mock endpoint has been invoked, you'd probably need to ensure that the mock have been really invoked.
+
+You can do it like this:
+
+```csharp
+var invoked = container.Verify("API Pastries", "0.0.1");
+```
+
+Or like this:
+
+```csharp
+var serviceInvocationsCount = container.GetServiceInvocationsCount("API Pastries", "0.0.1");
+```
+
 ### Launching new contract-tests
 
 If you want to ensure that your application under test is conformant to an OpenAPI contract (or other type of contract),

--- a/src/Microcks.Testcontainers/Microcks.Testcontainers.csproj
+++ b/src/Microcks.Testcontainers/Microcks.Testcontainers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
@@ -15,7 +15,6 @@
 //
 //
 
-using ICSharpCode.SharpZipLib.Zip;
 using Microcks.Testcontainers.Model;
 using System.IO;
 using System.Net;
@@ -239,18 +238,6 @@ public static class MicrocksContainerExtensions
     }
 
     /// <summary>
-    /// Verify if a service has been invoked at least once.
-    /// </summary>
-    /// <param name="container">Microcks container</param>
-    /// <param name="serviceName">Service name</param>
-    /// <param name="serviceVersion">Service version</param>            
-    /// <returns>True if the service has been invoked at least once, false otherwise</returns>
-    public static Boolean Verify(this MicrocksContainer container, string serviceName, string serviceVersion)
-    {
-        return Verify(container, serviceName, serviceVersion, null);
-    }
-
-    /// <summary>
     /// Verify if a service has been invoked at least once at a given date.
     /// </summary>
     /// <param name="container">Microcks container</param>
@@ -258,26 +245,14 @@ public static class MicrocksContainerExtensions
     /// <param name="serviceVersion">Service version</param>
     /// <param name="invocationDate">Date of invocation</param>
     /// <returns>True if the service has been invoked at least once, false otherwise</returns>
-    public static Boolean Verify(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate)
+    public static async Task<Boolean> Verify(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate = null)
     {
-        var dailyInvocationStatistic = container.GetServiceInvocations(serviceName, serviceVersion, invocationDate).Result;
+        var dailyInvocationStatistic = await container.GetServiceInvocations(serviceName, serviceVersion, invocationDate);
         if (dailyInvocationStatistic != null)
         {
             return dailyInvocationStatistic.DailyCount > 0;
         }
         return false;
-    }
-
-    /// <summary>
-    /// Get the number of invocations for a service.
-    /// </summary>
-    /// <param name="container">Microcks container</param>
-    /// <param name="serviceName">Service name</param>
-    /// <param name="serviceVersion">Service version</param>
-    /// <returns>Number of invocations</returns>
-    public static long GetServiceInvocationsCount(this MicrocksContainer container, string serviceName, string serviceVersion)
-    {
-        return GetServiceInvocationsCount(container, serviceName, serviceVersion, null);
     }
 
     /// <summary>
@@ -288,9 +263,9 @@ public static class MicrocksContainerExtensions
     /// <param name="serviceVersion">Service version</param>
     /// <param name="invocationDate">Date of invocation</param>
     /// <returns>Number of invocations</returns>
-    public static long GetServiceInvocationsCount(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate)
+    public static async Task<long> GetServiceInvocationsCount(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate = null)
     {
-        var dailyInvocationStatistic = container.GetServiceInvocations(serviceName, serviceVersion, invocationDate).Result;
+        var dailyInvocationStatistic = await container.GetServiceInvocations(serviceName, serviceVersion, invocationDate);
         if (dailyInvocationStatistic != null)
         {
             return dailyInvocationStatistic.DailyCount;
@@ -298,7 +273,7 @@ public static class MicrocksContainerExtensions
         return 0;
     }
 
-    internal static async Task<DailyInvocationStatistic> GetServiceInvocations(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate)
+    internal static async Task<DailyInvocationStatistic> GetServiceInvocations(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate = null)
     {
         // Encode service name and version and take care of replacing '+' by '%20' as metrics API
         // does not handle '+' in URL path.

--- a/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
@@ -245,9 +245,9 @@ public static class MicrocksContainerExtensions
     /// <param name="serviceVersion">Service version</param>
     /// <param name="invocationDate">Date of invocation</param>
     /// <returns>True if the service has been invoked at least once, false otherwise</returns>
-    public static async Task<Boolean> Verify(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate = null)
+    public static async Task<bool> VerifyAsync(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate = null)
     {
-        var dailyInvocationStatistic = await container.GetServiceInvocations(serviceName, serviceVersion, invocationDate);
+        var dailyInvocationStatistic = await container.GetServiceInvocationsAsync(serviceName, serviceVersion, invocationDate);
         if (dailyInvocationStatistic != null)
         {
             return dailyInvocationStatistic.DailyCount > 0;
@@ -263,9 +263,9 @@ public static class MicrocksContainerExtensions
     /// <param name="serviceVersion">Service version</param>
     /// <param name="invocationDate">Date of invocation</param>
     /// <returns>Number of invocations</returns>
-    public static async Task<long> GetServiceInvocationsCount(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate = null)
+    public static async Task<long> GetServiceInvocationsCountAsync(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate = null)
     {
-        var dailyInvocationStatistic = await container.GetServiceInvocations(serviceName, serviceVersion, invocationDate);
+        var dailyInvocationStatistic = await container.GetServiceInvocationsAsync(serviceName, serviceVersion, invocationDate);
         if (dailyInvocationStatistic != null)
         {
             return dailyInvocationStatistic.DailyCount;
@@ -273,7 +273,7 @@ public static class MicrocksContainerExtensions
         return 0;
     }
 
-    internal static async Task<DailyInvocationStatistic> GetServiceInvocations(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate = null)
+    internal static async Task<DailyInvocationStatistic> GetServiceInvocationsAsync(this MicrocksContainer container, string serviceName, string serviceVersion, DateOnly? invocationDate = null)
     {
         // Encode service name and version and take care of replacing '+' by '%20' as metrics API
         // does not handle '+' in URL path.
@@ -292,8 +292,8 @@ public static class MicrocksContainerExtensions
         var response = await Client.GetAsync(url);
 
         if (response.StatusCode == HttpStatusCode.OK && response.Content.Headers.ContentLength > 0)
-            // Deserialize the response content to DailyInvocationStatistic object
-            // and return it.
+        // Deserialize the response content to DailyInvocationStatistic object
+        // and return it.
         {
             return await response.Content.ReadFromJsonAsync<DailyInvocationStatistic>();
         }

--- a/src/Microcks.Testcontainers/Model/DailyInvocationStatistic.cs
+++ b/src/Microcks.Testcontainers/Model/DailyInvocationStatistic.cs
@@ -1,0 +1,70 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+using System.Data;
+using System.Text.Json.Serialization;
+
+namespace Microcks.Testcontainers.Model;
+
+/// <summary>
+/// The daily statistic of a service mock invocations
+/// </summary>
+public class DailyInvocationStatistic
+{
+
+    /// <summary>
+    /// Id of statistic record.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Day of statistic record.
+    /// </summary>
+    [JsonPropertyName("day")]
+    public string Day { get; set; }
+
+    /// <summary>
+    /// Service name of statistic record.
+    /// </summary>
+    [JsonPropertyName("serviceName")]
+    public string ServiceName { get; set; }
+
+    /// <summary>
+    /// Service version of statistic record.
+    /// </summary>
+    [JsonPropertyName("serviceVersion")]
+    public string ServiceVersion { get; set; }
+
+    /// <summary>
+    /// Daily count of statistic record.
+    /// </summary>
+    [JsonPropertyName("dailyCount")]
+    public long DailyCount { get; set; }
+
+    /// <summary>
+    /// Hourly count of statistic record.
+    /// </summary>
+    [JsonPropertyName("hourlyCount")]
+    public Dictionary<string, Object> HourlyCount { get; set; }
+
+    /// <summary>
+    /// Minute count of statistic record.
+    /// </summary>
+    [JsonPropertyName("minuteCount")]
+    public Dictionary<string, Object> MinuteCount { get; set; }
+}

--- a/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksContractTestingFunctionalityTests.cs
@@ -28,128 +28,128 @@ namespace Microcks.Testcontainers.Tests;
 
 public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
 {
-    private readonly INetwork _network = new NetworkBuilder().Build();
-    private readonly MicrocksContainer _microcksContainer;
-    private readonly IContainer _badImpl;
-    private readonly IContainer _goodImpl;
+  private readonly INetwork _network = new NetworkBuilder().Build();
+  private readonly MicrocksContainer _microcksContainer;
+  private readonly IContainer _badImpl;
+  private readonly IContainer _goodImpl;
 
 
-    private static readonly string BAD_PASTRY_IMAGE = "quay.io/microcks/contract-testing-demo:01";
-    private static readonly string GOOD_PASTRY_IMAGE = "quay.io/microcks/contract-testing-demo:02";
+  private static readonly string BAD_PASTRY_IMAGE = "quay.io/microcks/contract-testing-demo:01";
+  private static readonly string GOOD_PASTRY_IMAGE = "quay.io/microcks/contract-testing-demo:02";
 
-    public MicrocksContractTestingFunctionalityTests()
+  public MicrocksContractTestingFunctionalityTests()
+  {
+    _microcksContainer = new MicrocksBuilder()
+        .WithNetwork(_network)
+        .Build();
+
+    _badImpl = new ContainerBuilder()
+      .WithImage(BAD_PASTRY_IMAGE)
+      .WithNetwork(_network)
+      .WithNetworkAliases("bad-impl")
+      .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(".*Example app listening on port 3001.*"))
+      .Build();
+
+    _goodImpl = new ContainerBuilder()
+      .WithImage(GOOD_PASTRY_IMAGE)
+      .WithNetwork(_network)
+      .WithNetworkAliases("good-impl")
+      .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(".*Example app listening on port 3002.*"))
+      .Build();
+  }
+
+  public Task DisposeAsync()
+  {
+    return Task.WhenAll(
+      _microcksContainer.DisposeAsync().AsTask(),
+      _badImpl.DisposeAsync().AsTask(),
+      _goodImpl.DisposeAsync().AsTask(),
+      _network.DisposeAsync().AsTask()
+    );
+  }
+
+  public Task InitializeAsync()
+  {
+    _microcksContainer.Started +=
+      (_, _) => _microcksContainer.ImportAsMainArtifact("apipastries-openapi.yaml");
+
+    return Task.WhenAll(
+      _network.CreateAsync(),
+      _microcksContainer.StartAsync(),
+      _badImpl.StartAsync(),
+      _goodImpl.StartAsync()
+    );
+  }
+
+  [Fact]
+  public void ShouldConfigRetrieval()
+  {
+    var uriBuilder = new UriBuilder(_microcksContainer.GetHttpEndpoint())
     {
-        _microcksContainer = new MicrocksBuilder()
-            .WithNetwork(_network)
-            .Build();
+      Path = "/api/keycloak/config"
+    };
 
-        _badImpl = new ContainerBuilder()
-          .WithImage(BAD_PASTRY_IMAGE)
-          .WithNetwork(_network)
-          .WithNetworkAliases("bad-impl")
-          .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(".*Example app listening on port 3001.*"))
-          .Build();
+    Given()
+      .When()
+      .Get(uriBuilder.ToString())
+      .Then()
+      .StatusCode(HttpStatusCode.OK);
+  }
 
-        _goodImpl = new ContainerBuilder()
-          .WithImage(GOOD_PASTRY_IMAGE)
-          .WithNetwork(_network)
-          .WithNetworkAliases("good-impl")
-          .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(".*Example app listening on port 3002.*"))
-          .Build();
-    }
-
-    public Task DisposeAsync()
+  [Fact]
+  public async Task ShouldReturnSuccess_WhenGoodImplementation()
+  {
+    var badTestRequest = new TestRequest
     {
-        return Task.WhenAll(
-          _microcksContainer.DisposeAsync().AsTask(),
-          _badImpl.DisposeAsync().AsTask(),
-          _goodImpl.DisposeAsync().AsTask(),
-          _network.DisposeAsync().AsTask()
-        );
-    }
+      ServiceId = "API Pastries:0.0.1",
+      RunnerType = TestRunnerType.OPEN_API_SCHEMA,
+      TestEndpoint = "http://bad-impl:3001",
+      Timeout = TimeSpan.FromMilliseconds(2000)
+    };
 
-    public Task InitializeAsync()
+    // First test should fail with validation failure messages.
+    TestResult badTestResult = await _microcksContainer.TestEndpointAsync(badTestRequest);
+    Assert.False(badTestResult.Success);
+    Assert.Equal("http://bad-impl:3001", badTestResult.TestedEndpoint);
+    Assert.Equal(3, badTestResult.TestCaseResults.Count);
+    Assert.Contains("string found, number expected", badTestResult.TestCaseResults[0].TestStepResults[0].Message);
+
+    // Retrieve messages for the failing test case.
+    List<RequestResponsePair> messages = await _microcksContainer.GetMessagesForTestCaseAsync(badTestResult, "GET /pastries");
+    Assert.Equal(3, messages.Count);
+    Assert.All(messages, message =>
     {
-        _microcksContainer.Started +=
-          (_, _) => _microcksContainer.ImportAsMainArtifact("apipastries-openapi.yaml");
+      Assert.NotNull(message.Request);
+      Assert.NotNull(message.Response);
+      Assert.NotNull(message.Response.Content);
+      // Check these are the correct requests.
+      Assert.NotNull(message.Request.QueryParameters);
+      Assert.Single(message.Request.QueryParameters);
+      Assert.Equal("size", message.Request.QueryParameters[0].Name);
+    });
 
-        return Task.WhenAll(
-          _network.CreateAsync(),
-          _microcksContainer.StartAsync(),
-          _badImpl.StartAsync(),
-          _goodImpl.StartAsync()
-        );
-    }
-
-    [Fact]
-    public void ShouldConfigRetrieval()
+    // Switch endpoint to good implementation
+    var goodTestRequest = new TestRequest
     {
-        var uriBuilder = new UriBuilder(_microcksContainer.GetHttpEndpoint())
-        {
-            Path = "/api/keycloak/config"
-        };
+      ServiceId = "API Pastries:0.0.1",
+      RunnerType = TestRunnerType.OPEN_API_SCHEMA,
+      TestEndpoint = "http://good-impl:3002",
+      Timeout = TimeSpan.FromMilliseconds(2000)
+    };
+    TestResult goodTestResult = await _microcksContainer.TestEndpointAsync(goodTestRequest);
+    Assert.True(goodTestResult.Success);
+    Assert.Equal("http://good-impl:3002", goodTestResult.TestedEndpoint);
+    Assert.Equal(3, goodTestResult.TestCaseResults.Count);
+    Assert.Empty(goodTestResult.TestCaseResults[0].TestStepResults[0].Message);
 
-        Given()
-          .When()
-          .Get(uriBuilder.ToString())
-          .Then()
-          .StatusCode(HttpStatusCode.OK);
-    }
-
-    [Fact]
-    public async Task ShouldReturnSuccess_WhenGoodImplementation()
+    // Test avec un header
+    var goodTestRequestWithHeader = new TestRequest
     {
-        var badTestRequest = new TestRequest
-        {
-            ServiceId = "API Pastries:0.0.1",
-            RunnerType = TestRunnerType.OPEN_API_SCHEMA,
-            TestEndpoint = "http://bad-impl:3001",
-            Timeout = TimeSpan.FromMilliseconds(2000)
-        };
-
-        // First test should fail with validation failure messages.
-        TestResult badTestResult = await _microcksContainer.TestEndpointAsync(badTestRequest);
-        Assert.False(badTestResult.Success);
-        Assert.Equal("http://bad-impl:3001", badTestResult.TestedEndpoint);
-        Assert.Equal(3, badTestResult.TestCaseResults.Count);
-        Assert.Contains("string found, number expected", badTestResult.TestCaseResults[0].TestStepResults[0].Message);
-
-        // Retrieve messages for the failing test case.
-        List<RequestResponsePair> messages = await _microcksContainer.GetMessagesForTestCaseAsync(badTestResult, "GET /pastries");
-        Assert.Equal(3, messages.Count);
-        Assert.All(messages, message =>
-        {
-          Assert.NotNull(message.Request);
-          Assert.NotNull(message.Response);
-          Assert.NotNull(message.Response.Content);
-          // Check these are the correct requests.
-          Assert.NotNull(message.Request.QueryParameters);
-          Assert.Single(message.Request.QueryParameters);
-          Assert.Equal("size", message.Request.QueryParameters[0].Name);
-        });
-
-        // Switch endpoint to good implementation
-        var goodTestRequest = new TestRequest
-        {
-            ServiceId = "API Pastries:0.0.1",
-            RunnerType = TestRunnerType.OPEN_API_SCHEMA,
-            TestEndpoint = "http://good-impl:3002",
-            Timeout = TimeSpan.FromMilliseconds(2000)
-        };
-        TestResult goodTestResult = await _microcksContainer.TestEndpointAsync(goodTestRequest);
-        Assert.True(goodTestResult.Success);
-        Assert.Equal("http://good-impl:3002", goodTestResult.TestedEndpoint);
-        Assert.Equal(3, goodTestResult.TestCaseResults.Count);
-        Assert.Empty(goodTestResult.TestCaseResults[0].TestStepResults[0].Message);
-
-        // Test avec un header
-        var goodTestRequestWithHeader = new TestRequest
-        {
-            ServiceId = "API Pastries:0.0.1",
-            RunnerType = TestRunnerType.OPEN_API_SCHEMA,
-            TestEndpoint = "http://good-impl:3002",
-            Timeout = TimeSpan.FromSeconds(2),
-            OperationsHeaders = new Dictionary<string, List<Header>>()
+      ServiceId = "API Pastries:0.0.1",
+      RunnerType = TestRunnerType.OPEN_API_SCHEMA,
+      TestEndpoint = "http://good-impl:3002",
+      Timeout = TimeSpan.FromSeconds(2),
+      OperationsHeaders = new Dictionary<string, List<Header>>()
               {
                 {
                   "GET /pastries",
@@ -162,25 +162,25 @@ public sealed class MicrocksContractTestingFunctionalityTests : IAsyncLifetime
                   }
                 }
               }
-        };
+    };
 
-        TestResult goodTestResultWithHeader = await _microcksContainer.TestEndpointAsync(goodTestRequestWithHeader);
-        Assert.True(goodTestResultWithHeader.Success);
-        Assert.Equal("http://good-impl:3002", goodTestResultWithHeader.TestedEndpoint);
-        Assert.Equal(3, goodTestResultWithHeader.TestCaseResults.Count);
-        Assert.Empty(goodTestResultWithHeader.TestCaseResults[0].TestStepResults[0].Message);
-        Assert.Single(goodTestResultWithHeader.OperationsHeaders);
-        Assert.True(goodTestResultWithHeader.OperationsHeaders.ContainsKey("GET /pastries"));
-        Assert.Single(goodTestResultWithHeader.OperationsHeaders["GET /pastries"]);
-        var header = goodTestResultWithHeader.OperationsHeaders["GET /pastries"][0];
-        Assert.Equal("X-Custom-Header-1", header.Name);
+    TestResult goodTestResultWithHeader = await _microcksContainer.TestEndpointAsync(goodTestRequestWithHeader);
+    Assert.True(goodTestResultWithHeader.Success);
+    Assert.Equal("http://good-impl:3002", goodTestResultWithHeader.TestedEndpoint);
+    Assert.Equal(3, goodTestResultWithHeader.TestCaseResults.Count);
+    Assert.Empty(goodTestResultWithHeader.TestCaseResults[0].TestStepResults[0].Message);
+    Assert.Single(goodTestResultWithHeader.OperationsHeaders);
+    Assert.True(goodTestResultWithHeader.OperationsHeaders.ContainsKey("GET /pastries"));
+    Assert.Single(goodTestResultWithHeader.OperationsHeaders["GET /pastries"]);
+    var header = goodTestResultWithHeader.OperationsHeaders["GET /pastries"][0];
+    Assert.Equal("X-Custom-Header-1", header.Name);
 
-        var actualItems = header.Values.Split(",");
-        var expectedItems = new[] { "value1", "value2", "value3" };
+    var actualItems = header.Values.Split(",");
+    var expectedItems = new[] { "value1", "value2", "value3" };
 
-        foreach (var expectedItem in expectedItems)
-        {
-            Assert.Contains(expectedItem, actualItems);
-        }
+    foreach (var expectedItem in expectedItems)
+    {
+      Assert.Contains(expectedItem, actualItems);
     }
+  }
 }

--- a/tests/Microcks.Testcontainers.Tests/MicrocksMockingFunctionalityTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksMockingFunctionalityTest.cs
@@ -23,6 +23,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace Microcks.Testcontainers.Tests;
 
@@ -112,12 +113,12 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
     }
 
     [Fact]
-    public void ShouldMockVariousCapabilities()
+    public async Task ShouldMockVariousCapabilities()
     {
         var pastries = _microcksContainer.GetRestMockEndpoint("API Pastries", "0.0.1");
 
-        Assert.False(_microcksContainer.Verify("API Pastries", "0.0.1"));
-        Assert.Equal(0, _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
+        Assert.False(await _microcksContainer.Verify("API Pastries", "0.0.1"));
+        Assert.Equal(0, await _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
 
         Given()
           .When()
@@ -126,8 +127,8 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
           .StatusCode(HttpStatusCode.OK)
           .Body("$.name", IsEqualMatcher<string>.EqualTo("Millefeuille"));
 
-        Assert.True(_microcksContainer.Verify("API Pastries", "0.0.1"));
-        Assert.Equal(1, _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
+        Assert.True(await _microcksContainer.Verify("API Pastries", "0.0.1"));
+        Assert.Equal(1, await _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
 
         // Vérifier que le mock de l'API Pastry est bien disponible
         Given()
@@ -137,8 +138,8 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
           .StatusCode(HttpStatusCode.OK)
           .Body("$.name", IsEqualMatcher<string>.EqualTo("Eclair Chocolat"));
 
-        Assert.True(_microcksContainer.Verify("API Pastries", "0.0.1"));
-        Assert.Equal(2, _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
+        Assert.True(await _microcksContainer.Verify("API Pastries", "0.0.1"));
+        Assert.Equal(2, await _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
 
         // Switch to the other version of the API Pastry
         var baseApiUrl = _microcksContainer.GetRestMockEndpoint("API Pastry - 2.0", "2.0.0");
@@ -150,8 +151,8 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
           .StatusCode(HttpStatusCode.OK)
           .Body("$.name", IsEqualMatcher<string>.EqualTo("Millefeuille"));
 
-        Assert.True(_microcksContainer.Verify("API Pastry - 2.0", "2.0.0"));
-        Assert.Equal(1, _microcksContainer.GetServiceInvocationsCount("API Pastry - 2.0", "2.0.0"));
+        Assert.True(await _microcksContainer.Verify("API Pastry - 2.0", "2.0.0"));
+        Assert.Equal(1, await _microcksContainer.GetServiceInvocationsCount("API Pastry - 2.0", "2.0.0"));
     }
 
 }

--- a/tests/Microcks.Testcontainers.Tests/MicrocksMockingFunctionalityTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksMockingFunctionalityTest.cs
@@ -29,130 +29,130 @@ namespace Microcks.Testcontainers.Tests;
 
 public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
 {
-    private readonly MicrocksContainer _microcksContainer = new MicrocksBuilder()
-      .WithSnapshots("microcks-repository.json")
-      .WithMainArtifacts("apipastries-openapi.yaml", Path.Combine("subdir", "weather-forecast-openapi.yaml"))
-      .WithMainRemoteArtifacts("https://raw.githubusercontent.com/microcks/microcks/master/samples/APIPastry-openapi.yaml")
-      .WithSecondaryArtifacts("apipastries-postman-collection.json")
-      .Build();
+  private readonly MicrocksContainer _microcksContainer = new MicrocksBuilder()
+    .WithSnapshots("microcks-repository.json")
+    .WithMainArtifacts("apipastries-openapi.yaml", Path.Combine("subdir", "weather-forecast-openapi.yaml"))
+    .WithMainRemoteArtifacts("https://raw.githubusercontent.com/microcks/microcks/master/samples/APIPastry-openapi.yaml")
+    .WithSecondaryArtifacts("apipastries-postman-collection.json")
+    .Build();
 
-    public Task DisposeAsync()
+  public Task DisposeAsync()
+  {
+    return _microcksContainer.DisposeAsync().AsTask();
+  }
+
+  public Task InitializeAsync()
+  {
+    return _microcksContainer.StartAsync();
+  }
+
+  [Fact]
+  public void ShouldConfigureMockEndpoints()
+  {
+    string baseWsUrl = $"{_microcksContainer.GetSoapMockEndpoint("Pastries Service", "1.0")}";
+    Assert.Equal($"{_microcksContainer.GetHttpEndpoint()}soap/Pastries Service/1.0", baseWsUrl);
+
+    string baseApiUrl = $"{_microcksContainer.GetRestMockEndpoint("API Pastries", "0.0.1")}";
+    Assert.Equal($"{_microcksContainer.GetHttpEndpoint()}rest/API Pastries/0.0.1", baseApiUrl);
+
+    string baseGraphUrl = $"{_microcksContainer.GetGraphQLMockEndpoint("Pastries Graph", "1")}";
+    Assert.Equal($"{_microcksContainer.GetHttpEndpoint()}graphql/Pastries Graph/1", baseGraphUrl);
+
+    string baseGrpcUrl = $"{_microcksContainer.GetGrpcMockEndpoint()}";
+    Assert.Equal($"grpc://{_microcksContainer.Hostname}:{_microcksContainer.GetMappedPublicPort(MicrocksBuilder.MicrocksGrpcPort)}/", baseGrpcUrl);
+  }
+
+  [Fact]
+  public void ShouldConfigRetrieval()
+  {
+    var uriBuilder = new UriBuilder(_microcksContainer.GetHttpEndpoint())
     {
-        return _microcksContainer.DisposeAsync().AsTask();
-    }
+      Path = "/api/keycloak/config"
+    };
 
-    public Task InitializeAsync()
+    Given()
+      .When()
+      .Get(uriBuilder.ToString())
+      .Then()
+      .StatusCode(HttpStatusCode.OK);
+  }
+
+  [Fact]
+  public async Task ShouldAvailableServices()
+  {
+    var uriBuilder = new UriBuilder(_microcksContainer.GetHttpEndpoint())
     {
-        return _microcksContainer.StartAsync();
-    }
+      Path = "/api/services"
+    };
 
-    [Fact]
-    public void ShouldConfigureMockEndpoints()
-    {
-        string baseWsUrl = $"{_microcksContainer.GetSoapMockEndpoint("Pastries Service", "1.0")}";
-        Assert.Equal($"{_microcksContainer.GetHttpEndpoint()}soap/Pastries Service/1.0", baseWsUrl);
+    var verifiableResponse = Given()
+      .Log(new LogConfiguration { RequestLogLevel = RequestLogLevel.All })
+      .When()
+      .Get(uriBuilder.ToString())
+      .Then()
+      .StatusCode(HttpStatusCode.OK);
 
-        string baseApiUrl = $"{_microcksContainer.GetRestMockEndpoint("API Pastries", "0.0.1")}";
-        Assert.Equal($"{_microcksContainer.GetHttpEndpoint()}rest/API Pastries/0.0.1", baseApiUrl);
+    // newtonsoft json jsonpath $.length is not supported
+    var services = await verifiableResponse
+      .Extract()
+      .Response().Content.ReadAsStringAsync();
 
-        string baseGraphUrl = $"{_microcksContainer.GetGraphQLMockEndpoint("Pastries Graph", "1")}";
-        Assert.Equal($"{_microcksContainer.GetHttpEndpoint()}graphql/Pastries Graph/1", baseGraphUrl);
+    var document = JsonDocument.Parse(services);
+    Assert.Equal(7, document.RootElement.GetArrayLength());
 
-        string baseGrpcUrl = $"{_microcksContainer.GetGrpcMockEndpoint()}";
-        Assert.Equal($"grpc://{_microcksContainer.Hostname}:{_microcksContainer.GetMappedPublicPort(MicrocksBuilder.MicrocksGrpcPort)}/", baseGrpcUrl);
-    }
+    verifiableResponse.Body("$[0:].name", Has.Items(
+        Is.EqualTo("Petstore API"),
+        Is.EqualTo("HelloService Mock"),
+        Is.EqualTo("io.github.microcks.grpc.hello.v1.HelloService"),
+        Is.EqualTo("Movie Graph API"),
+        Is.EqualTo("API Pastry - 2.0"),
+        Is.EqualTo("API Pastries"),
+        Is.EqualTo("WeatherForecast API")
+        ),
+      VerifyAs.Json);
+  }
 
-    [Fact]
-    public void ShouldConfigRetrieval()
-    {
-        var uriBuilder = new UriBuilder(_microcksContainer.GetHttpEndpoint())
-        {
-            Path = "/api/keycloak/config"
-        };
+  [Fact]
+  public async Task ShouldMockVariousCapabilities()
+  {
+    var pastries = _microcksContainer.GetRestMockEndpoint("API Pastries", "0.0.1");
 
-        Given()
-          .When()
-          .Get(uriBuilder.ToString())
-          .Then()
-          .StatusCode(HttpStatusCode.OK);
-    }
+    Assert.False(await _microcksContainer.VerifyAsync("API Pastries", "0.0.1"));
+    Assert.Equal(0, await _microcksContainer.GetServiceInvocationsCountAsync("API Pastries", "0.0.1"));
 
-    [Fact]
-    public async Task ShouldAvailableServices()
-    {
-        var uriBuilder = new UriBuilder(_microcksContainer.GetHttpEndpoint())
-        {
-            Path = "/api/services"
-        };
+    Given()
+      .When()
+      .Get($"{pastries}/pastries/Millefeuille")
+      .Then()
+      .StatusCode(HttpStatusCode.OK)
+      .Body("$.name", IsEqualMatcher<string>.EqualTo("Millefeuille"));
 
-        var verifiableResponse = Given()
-          .Log(new LogConfiguration { RequestLogLevel = RequestLogLevel.All })
-          .When()
-          .Get(uriBuilder.ToString())
-          .Then()
-          .StatusCode(HttpStatusCode.OK);
+    Assert.True(await _microcksContainer.VerifyAsync("API Pastries", "0.0.1"));
+    Assert.Equal(1, await _microcksContainer.GetServiceInvocationsCountAsync("API Pastries", "0.0.1"));
 
-        // newtonsoft json jsonpath $.length is not supported
-        var services = await verifiableResponse
-          .Extract()
-          .Response().Content.ReadAsStringAsync();
+    // Vérifier que le mock de l'API Pastry est bien disponible
+    Given()
+      .When()
+      .Get($"{pastries}/pastries/Eclair Chocolat")
+      .Then()
+      .StatusCode(HttpStatusCode.OK)
+      .Body("$.name", IsEqualMatcher<string>.EqualTo("Eclair Chocolat"));
 
-        var document = JsonDocument.Parse(services);
-        Assert.Equal(7, document.RootElement.GetArrayLength());
+    Assert.True(await _microcksContainer.VerifyAsync("API Pastries", "0.0.1"));
+    Assert.Equal(2, await _microcksContainer.GetServiceInvocationsCountAsync("API Pastries", "0.0.1"));
 
-        verifiableResponse.Body("$[0:].name", Has.Items(
-            Is.EqualTo("Petstore API"),
-            Is.EqualTo("HelloService Mock"),
-            Is.EqualTo("io.github.microcks.grpc.hello.v1.HelloService"),
-            Is.EqualTo("Movie Graph API"),
-            Is.EqualTo("API Pastry - 2.0"),
-            Is.EqualTo("API Pastries"),
-            Is.EqualTo("WeatherForecast API")
-            ),
-          VerifyAs.Json);
-    }
+    // Switch to the other version of the API Pastry
+    var baseApiUrl = _microcksContainer.GetRestMockEndpoint("API Pastry - 2.0", "2.0.0");
 
-    [Fact]
-    public async Task ShouldMockVariousCapabilities()
-    {
-        var pastries = _microcksContainer.GetRestMockEndpoint("API Pastries", "0.0.1");
+    Given()
+      .When()
+      .Get($"{baseApiUrl}" + "/pastry/Millefeuille")
+      .Then()
+      .StatusCode(HttpStatusCode.OK)
+      .Body("$.name", IsEqualMatcher<string>.EqualTo("Millefeuille"));
 
-        Assert.False(await _microcksContainer.Verify("API Pastries", "0.0.1"));
-        Assert.Equal(0, await _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
-
-        Given()
-          .When()
-          .Get($"{pastries}/pastries/Millefeuille")
-          .Then()
-          .StatusCode(HttpStatusCode.OK)
-          .Body("$.name", IsEqualMatcher<string>.EqualTo("Millefeuille"));
-
-        Assert.True(await _microcksContainer.Verify("API Pastries", "0.0.1"));
-        Assert.Equal(1, await _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
-
-        // Vérifier que le mock de l'API Pastry est bien disponible
-        Given()
-          .When()
-          .Get($"{pastries}/pastries/Eclair Chocolat")
-          .Then()
-          .StatusCode(HttpStatusCode.OK)
-          .Body("$.name", IsEqualMatcher<string>.EqualTo("Eclair Chocolat"));
-
-        Assert.True(await _microcksContainer.Verify("API Pastries", "0.0.1"));
-        Assert.Equal(2, await _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
-
-        // Switch to the other version of the API Pastry
-        var baseApiUrl = _microcksContainer.GetRestMockEndpoint("API Pastry - 2.0", "2.0.0");
-
-        Given()
-          .When()
-          .Get($"{baseApiUrl}" + "/pastry/Millefeuille")
-          .Then()
-          .StatusCode(HttpStatusCode.OK)
-          .Body("$.name", IsEqualMatcher<string>.EqualTo("Millefeuille"));
-
-        Assert.True(await _microcksContainer.Verify("API Pastry - 2.0", "2.0.0"));
-        Assert.Equal(1, await _microcksContainer.GetServiceInvocationsCount("API Pastry - 2.0", "2.0.0"));
-    }
+    Assert.True(await _microcksContainer.VerifyAsync("API Pastry - 2.0", "2.0.0"));
+    Assert.Equal(1, await _microcksContainer.GetServiceInvocationsCountAsync("API Pastry - 2.0", "2.0.0"));
+  }
 
 }

--- a/tests/Microcks.Testcontainers.Tests/MicrocksMockingFunctionalityTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksMockingFunctionalityTest.cs
@@ -116,6 +116,9 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
     {
         var pastries = _microcksContainer.GetRestMockEndpoint("API Pastries", "0.0.1");
 
+        Assert.False(_microcksContainer.Verify("API Pastries", "0.0.1"));
+        Assert.Equal(0, _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
+
         Given()
           .When()
           .Get($"{pastries}/pastries/Millefeuille")
@@ -123,6 +126,8 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
           .StatusCode(HttpStatusCode.OK)
           .Body("$.name", IsEqualMatcher<string>.EqualTo("Millefeuille"));
 
+        Assert.True(_microcksContainer.Verify("API Pastries", "0.0.1"));
+        Assert.Equal(1, _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
 
         // Vérifier que le mock de l'API Pastry est bien disponible
         Given()
@@ -132,6 +137,10 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
           .StatusCode(HttpStatusCode.OK)
           .Body("$.name", IsEqualMatcher<string>.EqualTo("Eclair Chocolat"));
 
+        Assert.True(_microcksContainer.Verify("API Pastries", "0.0.1"));
+        Assert.Equal(2, _microcksContainer.GetServiceInvocationsCount("API Pastries", "0.0.1"));
+
+        // Switch to the other version of the API Pastry
         var baseApiUrl = _microcksContainer.GetRestMockEndpoint("API Pastry - 2.0", "2.0.0");
 
         Given()
@@ -140,6 +149,9 @@ public sealed class MicrocksMockingFunctionalityTest : IAsyncLifetime
           .Then()
           .StatusCode(HttpStatusCode.OK)
           .Body("$.name", IsEqualMatcher<string>.EqualTo("Millefeuille"));
+
+        Assert.True(_microcksContainer.Verify("API Pastry - 2.0", "2.0.0"));
+        Assert.Equal(1, _microcksContainer.GetServiceInvocationsCount("API Pastry - 2.0", "2.0.0"));
     }
 
 }


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Provides new `Verify()` and `GetServiceInvocationsCount()` methods on `MicrocksContainerExtensions` to address #24

## Readiness Checklist

### Author/Contributor

- [X] If documentation is needed for this change, has that been included in this pull request
- [X] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [X] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [ ] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
