### PR TITLE
fix: flaky tests on WebSocket Tests

### DIFF
--- a/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
@@ -29,6 +29,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microcks.Testcontainers.Tests.Async;
 
+[Collection(nameof(WsCollection))]
 public sealed class MicrocksAsyncFeatureTest : IAsyncLifetime
 {
     /// <summary>

--- a/tests/Microcks.Testcontainers.Tests/Async/WaitForConditionAsyncTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/Async/WaitForConditionAsyncTests.cs
@@ -22,11 +22,12 @@ using Microcks.Testcontainers.Model;
 using System;
 using System.Diagnostics;
 
-namespace Microcks.Testcontainers.Tests;
+namespace Microcks.Testcontainers.Tests.Async;
 
 /// <summary>
 /// This class contains tests for the WaitForConditionAsync method.
 /// </summary>
+[Collection(nameof(WsCollection))]
 public class WaitForConditionAsyncTests : IAsyncLifetime
 {
     /// <summary>

--- a/tests/Microcks.Testcontainers.Tests/Async/WsCollection.cs
+++ b/tests/Microcks.Testcontainers.Tests/Async/WsCollection.cs
@@ -1,0 +1,21 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+namespace Microcks.Testcontainers.Tests.Async;
+
+[CollectionDefinition(nameof(WsCollection), DisableParallelization = true)]
+public class WsCollection { }


### PR DESCRIPTION
# Pull Request
## Proposed Changes

This PR disables parallel execution for the MicrocksAsyncFeatureTest class to prevent resource sharing issues between the Microcks containers and the good and bad implementation containers. By ensuring that these tests run sequentially, we aim to eliminate conflicts and unpredictable results caused by simultaneous access to shared resources.

Added the [Collection] attribute to the MicrocksAsyncFeatureTest class to group tests that should not run in parallel.
This change ensures that each test has exclusive access to the resources it requires (websocket container), leading to more reliable and consistent test outcomes.

[Issue](https://github.com/microcks/microcks-testcontainers-dotnet/issues/44)

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [x] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [x] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
