### PR TITLE
chore(dependabot): reorganize package updates and add dotnet-sdk support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,51 @@
 version: 2
 updates:
-  - package-ecosystem: "nuget"
-    directory: "/"
+  #  https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/
+  - package-ecosystem: "dotnet-sdk"
+    directory: /
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 1
+
+  # NuGet package updates
+  - package-ecosystem: nuget
+    directory: /
     schedule:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 3
     rebase-strategy: disabled
-  - package-ecosystem: "github-actions"
-    directory: "/"
+    groups:
+      microsoft-sbom:
+        patterns: ['Microsoft.Sbom.Targets']
+      Microsoft.NET.Test.Sdk:
+        patterns: ['Microsoft.NET.Test.Sdk']
+      coverlet.collector:
+        patterns: ['coverlet.collector']
+      testcontainers:
+        patterns: ['Testcontainers*']
+      microsoft:
+        patterns: [Microsoft.*, System.*]
+      xunit:
+        patterns: [xunit.*]
+      # Grouping for Testcontainers
+      kafka:
+        patterns: ['Confluent.Kafka']
+      RabbitMQ.Client:
+        patterns: ['RabbitMQ.Client']
+      RestAssured.Net:
+        patterns: ['RestAssured.Net']
+      all-dependencies:
+        patterns: ['*']
+
+# Github Actions updates
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 3
     rebase-strategy: disabled
+
+    


### PR DESCRIPTION
# Pull Request

This PR reorganizes the Dependabot configuration to improve dependency management for this monorepo:

- **Adds dotnet-sdk support:** Dependabot will now automatically check for .NET SDK updates.
- **Groups NuGet package updates:** Dependencies are grouped by monorepo (Microsoft*) context making updates easier to review.
- **Includes an all-dependencies group:** Ensures all packages can be updated together if needed.

Grouping dependencies by monorepo context helps streamline updates, minimize pull request volume, and maintain a

## Proposed Changes

<img width="857" height="298" alt="image" src="https://github.com/user-attachments/assets/1de800bb-3094-4e82-bcbb-786f0aa2bc1d" />

Sample here: https://github.com/SebastienDegodez/microcks-testcontainers-dotnet/pulls

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [ ] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [ ] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
