### PR TITLE
feat: #95 Add Postman contract-testing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The list of supported features is the following:
 -   Mocking and contract-testing of GraphQL APIs,
 -   Mocking and contract-testing of gRPC APIs.
 
-To support features like Asynchronous contract-testing, we introduced `MicrocksContainersEnsemble` that allows managing
+To support features like Asynchronous API and `POSTMAN`contract-testing, we introduced `MicrocksContainersEnsemble` that allows managing
 additional Microcks services. `MicrocksContainersEnsemble` allow you to implement
 [Different levels of API contract testing](https://medium.com/@lbroudoux/different-levels-of-api-contract-testing-with-microcks-ccc0847f8c97)
 in the Inner Loop with Testcontainers!
@@ -242,7 +242,8 @@ You can create and build an ensemble that way:
 
 ```csharp
 MicrocksContainersEnsemble ensemble = new MicrocksContainerEnsemble(network, MicrocksImage)
-    .WithMainArtifacts("pastry-orders-asyncapi.yml");
+    .WithMainArtifacts("apipastries-openapi.yaml")
+    .WithSecondaryArtifacts("apipastries-postman-collection.json");
 
 await ensemble.StartAsync();
 ```
@@ -263,6 +264,29 @@ MicrocksContainersEnsemble ensemble = new MicrocksContainerEnsemble(network, Mic
     .WithAsyncFeature();
 
 await ensemble.StartAsync();
+```
+
+#### Postman contract-testing
+
+On this `ensemble` you may want to enable additional features such as Postman contract-testing:
+
+```csharp
+ensemble.WithPostman();
+await ensemble.StartAsync();
+```
+
+You can execute a `POSTMAN` test using an ensemble that way:
+
+```csharp
+var testRequest = new TestRequest
+{
+    ServiceId = "API Pastries:0.0.1",
+    RunnerType = TestRunnerType.POSTMAN,
+    TestEndpoint = "http://good-impl:3003",
+    Timeout = TimeSpan.FromSeconds(3)
+};
+
+TestResult testResult = await _ensemble.MicrocksContainer.TestEndpointAsync(testRequest);
 ```
 
 #### Asynchronous API support

--- a/tests/Microcks.Testcontainers.Tests/PostmanContractTestingFunctionalityTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/PostmanContractTestingFunctionalityTests.cs
@@ -1,0 +1,117 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+using System;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Microcks.Testcontainers.Model;
+using TestResult = Microcks.Testcontainers.Model.TestResult;
+
+namespace Microcks.Testcontainers.Tests;
+
+public sealed class PostmanContractTestingFunctionalityTests : IAsyncLifetime
+{
+    private static readonly string BAD_PASTRY_IMAGE = "quay.io/microcks/contract-testing-demo:02";
+    private static readonly string GOOD_PASTRY_IMAGE = "quay.io/microcks/contract-testing-demo:03";
+
+    private readonly INetwork _network = new NetworkBuilder().Build();
+
+    private readonly IContainer _badImpl;
+    private readonly IContainer _goodImpl;
+    private readonly MicrocksContainerEnsemble _ensemble;
+
+
+    public PostmanContractTestingFunctionalityTests()
+    {
+        _badImpl = new ContainerBuilder()
+            .WithImage(BAD_PASTRY_IMAGE)
+            .WithNetwork(_network)
+            .WithNetworkAliases("bad-impl")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(".*Example app listening on port 3002.*"))
+            .Build();
+
+        _goodImpl = new ContainerBuilder()
+            .WithImage(GOOD_PASTRY_IMAGE)
+            .WithNetwork(_network)
+            .WithNetworkAliases("good-impl")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(".*Example app listening on port 3003.*"))
+            .Build();
+
+        _ensemble = new MicrocksContainerEnsemble(_network, "quay.io/microcks/microcks-uber:1.12.1")
+            .WithMainArtifacts("apipastries-openapi.yaml")
+            .WithSecondaryArtifacts("apipastries-postman-collection.json")
+            .WithPostman();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _ensemble.StartAsync();
+        await _badImpl.StartAsync();
+        await _goodImpl.StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _badImpl.DisposeAsync();
+        await _goodImpl.DisposeAsync();
+        await _ensemble.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ShouldFail_WhenBadImplementation()
+    {
+        var testRequest = new TestRequest
+        {
+            ServiceId = "API Pastries:0.0.1",
+            RunnerType = TestRunnerType.POSTMAN,
+            TestEndpoint = "http://bad-impl:3002",
+            Timeout = TimeSpan.FromSeconds(3)
+        };
+
+        // Test should fail with validation failure messages.
+        TestResult badTestResult = await _ensemble.MicrocksContainer.TestEndpointAsync(testRequest);
+        Assert.False(badTestResult.Success);
+        Assert.Equal("http://bad-impl:3002", badTestResult.TestedEndpoint);
+        Assert.Equal(3, badTestResult.TestCaseResults.Count);
+        // Postman runner stop at first failure so there's just 1 testStepResult per testCaseResult
+        Assert.Single(badTestResult.TestCaseResults[0].TestStepResults);
+        // Order is not deterministic so it could be a matter of invalid size, invalid name or invalid price.
+        Assert.True(badTestResult.TestCaseResults[0].TestStepResults[0].Message.Contains("Valid size in response pastries")
+            || badTestResult.TestCaseResults[0].TestStepResults[0].Message.Contains("Valid name in response pastry")
+            || badTestResult.TestCaseResults[0].TestStepResults[0].Message.Contains("Valid price in response pastry"));
+    }
+
+    [Fact]
+    public async Task ShouldSucceed_WhenGoodImplementation()
+    {
+        var testRequest = new TestRequest
+        {
+            ServiceId = "API Pastries:0.0.1",
+            RunnerType = TestRunnerType.POSTMAN,
+            TestEndpoint = "http://good-impl:3003",
+            Timeout = TimeSpan.FromSeconds(3)
+        };
+
+        // Test should succeed with no validation failure messages.
+        TestResult goodTestResult = await _ensemble.MicrocksContainer.TestEndpointAsync(testRequest);
+        Assert.True(goodTestResult.Success);
+        Assert.Equal("http://good-impl:3003", goodTestResult.TestedEndpoint);
+        Assert.Equal(3, goodTestResult.TestCaseResults.Count);
+        Assert.Null(goodTestResult.TestCaseResults[0].TestStepResults[0].Message);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Proposed Changes

This PR adds support for managing a Postman runtime container as part of an Ensemble and executing contract tests driven by a Postman Collection.

## Readiness Checklist

### Author/Contributor

- [X] If documentation is needed for this change, has that been included in this pull request
- [X] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [X] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [X] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
