### PR TITLE
Fix/group testcontainers dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       coverlet.collector:
         patterns: ['coverlet.collector']
       testcontainers:
-        patterns: ['Testcontainers*']
+        patterns: [ 'Testcontainers', 'Testcontainers.*']
       microsoft:
         patterns: [Microsoft.*, System.*]
       xunit:


### PR DESCRIPTION
# Pull Request
#126

## Proposed Changes

Update the Dependabot NuGet grouping for Testcontainers so it matches the actual NuGet package IDs. Dependabot was not grouping the Testcontainers packages because the pattern used ("Testcontainers*") does not match the NuGet package ID ("Testcontainers"). This change updates the group patterns to "Testcontainers" and "Testcontainers.*" so updates will be grouped correctly.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [x] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [x] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
