### PR TITLE
chore: remove net6.0 from TargetFrameworks in Microcks.Testcontainers.csproj

### DIFF
--- a/src/Microcks.Testcontainers/Microcks.Testcontainers.csproj
+++ b/src/Microcks.Testcontainers/Microcks.Testcontainers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <GenerateSBOM>true</GenerateSBOM>
     </PropertyGroup>


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Remove all .NET 6 target frameworks from project .csproj files
Issue: #132

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [x] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [x] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
