### PR TITLE
feat: #96 Adding secrets for remote artifacts

### DIFF
--- a/src/Microcks.Testcontainers/IArtifactAndSnapshotManager.cs
+++ b/src/Microcks.Testcontainers/IArtifactAndSnapshotManager.cs
@@ -18,27 +18,37 @@
 namespace Microcks.Testcontainers;
 
 /// <summary>
-/// Interface pour la gestion des artifacts et snapshots dans une approche fluide.
+/// Artifacts management interface for fluent approach.
 /// </summary>
 public interface IArtifactAndSnapshotManager<T>
 {
     /// <summary>
-    /// Ajoute des artifacts principaux.
+    /// Add main/primary artifacts.
     /// </summary>
     T WithMainArtifacts(params string[] mainArtifacts);
 
     /// <summary>
-    /// Ajoute des artifacts principaux distants.
+    /// Add main/primary remote artifacts.
     /// </summary>
     T WithMainRemoteArtifacts(params string[] mainRemoteArtifacts);
 
     /// <summary>
-    /// Ajoute des artifacts secondaires.
+    /// Add main/primary remote artifacts with a complete full definition of remote artifact.
+    /// </summary>
+    T WithMainRemoteArtifacts(params RemoteArtifact[] mainRemoteArtifacts);
+
+    /// <summary>
+    /// Add secondary artifacts.
     /// </summary>
     T WithSecondaryArtifacts(params string[] secondaryArtifacts);
 
     /// <summary>
-    /// Ajoute des snapshots.
+    /// Add secondary artifacts with a complete full definition of remote artifact.
+    /// </summary>
+    T WithSecondaryRemoteArtifacts(params RemoteArtifact[] secondaryRemoteArtifacts);
+
+    /// <summary>
+    /// Add snapshots.
     /// </summary>
     T WithSnapshots(params string[] snapshots);
 }

--- a/src/Microcks.Testcontainers/MicrocksContainerEnsemble.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainerEnsemble.cs
@@ -103,9 +103,21 @@ public class MicrocksContainerEnsemble : IAsyncDisposable, IArtifactAndSnapshotM
         return this;
     }
 
+    public MicrocksContainerEnsemble WithMainRemoteArtifacts(params RemoteArtifact[] remoteArtifacts)
+    {
+        this._microcksBuilder.WithMainRemoteArtifacts(remoteArtifacts);
+        return this;
+    }
+
     public MicrocksContainerEnsemble WithSecondaryArtifacts(params string[] secondaryArtifacts)
     {
         this._microcksBuilder.WithSecondaryArtifacts(secondaryArtifacts);
+        return this;
+    }
+
+    public MicrocksContainerEnsemble WithSecondaryRemoteArtifacts(params RemoteArtifact[] remoteArtifacts)
+    {
+        this._microcksBuilder.WithSecondaryRemoteArtifacts(remoteArtifacts);
         return this;
     }
 
@@ -115,10 +127,16 @@ public class MicrocksContainerEnsemble : IAsyncDisposable, IArtifactAndSnapshotM
         return this;
     }
 
+    public MicrocksContainerEnsemble WithSecrets(params Model.Secret[] secrets)
+    {
+        this._microcksBuilder.WithSecrets(secrets);
+        return this;
+    }
+
     /// <summary>
     /// Configures the Microcks container ensemble to include a Postman runtime container.
     /// </summary>
-    /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns
+    /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns>
     public MicrocksContainerEnsemble WithPostman()
     {
         return this.WithPostman("quay.io/microcks/microcks-postman-runtime:latest");

--- a/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainerExtensions.cs
@@ -172,9 +172,13 @@ public static class MicrocksContainerExtensions
         container.Logger.LogInformation($"Secret {secret.Name} has been created");
     }
 
-    internal static async Task DownloadArtifactAsync(this MicrocksContainer container, string remoteArtifactUrl, bool main)
+    internal static async Task DownloadArtifactAsync(this MicrocksContainer container, RemoteArtifact remoteArtifact, bool main)
     {
-        var content = new StringContent("mainArtifact=" + main + "&url=" + remoteArtifactUrl, Encoding.UTF8, "application/x-www-form-urlencoded");
+        var content = new StringContent("mainArtifact=" + main + "&url=" + remoteArtifact.Url, Encoding.UTF8, "application/x-www-form-urlencoded");
+        if (remoteArtifact.SecretName != null)
+        {
+            content = new StringContent("mainArtifact=" + main + "&url=" + remoteArtifact.Url + "&secretName=" + remoteArtifact.SecretName, Encoding.UTF8, "application/x-www-form-urlencoded");
+        }
         var result = await Client
             .PostAsync($"{container.GetHttpEndpoint()}api/artifact/download", content);
 
@@ -182,7 +186,7 @@ public static class MicrocksContainerExtensions
         {
             throw new Exception("Artifact has not been correctly downloaded");
         }
-        container.Logger.LogInformation($"Artifact {remoteArtifactUrl} has been downloaded");
+        container.Logger.LogInformation($"Artifact {remoteArtifact.Url} has been downloaded");
     }
 
     /// <summary>

--- a/src/Microcks.Testcontainers/RemoteArtifact.cs
+++ b/src/Microcks.Testcontainers/RemoteArtifact.cs
@@ -1,0 +1,43 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+/// <summary>
+/// Represents a remote artifact with its URL and associated secret name.
+/// </summary>
+public class RemoteArtifact
+{
+    /// <summary>
+    /// URL of remote artifact.
+    /// </summary>
+    public string Url { get; set; }
+
+    /// <summary>
+    /// Secret name to access remote artifact.
+    /// </summary>
+    public string SecretName { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemoteArtifact" /> class.
+    /// </summary>
+    /// <param name="url">URL of remote artifact.</param>
+    /// <param name="secretName">Secret name to access remote artifact.</param>
+    public RemoteArtifact(string url, string secretName)
+    {
+        Url = url;
+        SecretName = secretName;
+    }
+}


### PR DESCRIPTION
# Pull Request

This PR implements the required changes for #96

## Proposed Changes

It adds the ability to specify secrets to use for Microcks to download remote artifacts.
This PR also changes the order in which artifacts are loaded into the Microcks container:
* 1st the snapshots,
* Then the remote main artifacts,
* Then the remote secondary artifacts,
* Then the local main artifacts,
* Then the local secondary artifacts.

This PR also fixes a typo on the `MicrocksBuilder.WithSecret(Secret[] secrets)` method => it's now `WithSecrets()` as we're providing an array.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [X] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [X] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [X] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
