### PR TITLE
refactor: improve test structure and performance by utilizing fixtures

### DIFF
--- a/src/Microcks.Testcontainers/MicrocksBuilder.cs
+++ b/src/Microcks.Testcontainers/MicrocksBuilder.cs
@@ -192,7 +192,7 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
             _mainRemoteArtifacts = new List<RemoteArtifact>(urls.Length);
         }
         _mainRemoteArtifacts.AddRange(urls.Select(url => new RemoteArtifact(url, null)));
-        
+
         return this;
     }
 

--- a/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
+++ b/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncFeatureTest.cs
@@ -149,7 +149,7 @@ public sealed class MicrocksAsyncFeatureTest
         Assert.True(string.IsNullOrEmpty(testResult.TestCaseResults.First().TestStepResults.First().Message));
     }
 
-        /// <summary>
+    /// <summary>
     /// Test that verifies that the WaitForConditionAsync method throws a TaskCanceledException
     /// when the specified timeout is reached.
     /// </summary>

--- a/tests/Microcks.Testcontainers.Tests/Fixtures/MicrocksContractTestingFixture.cs
+++ b/tests/Microcks.Testcontainers.Tests/Fixtures/MicrocksContractTestingFixture.cs
@@ -1,0 +1,78 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+using System;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+
+namespace Microcks.Testcontainers.Tests.Fixtures;
+
+public sealed class MicrocksContractTestingFixture : IAsyncLifetime
+{
+    private static readonly string BAD_PASTRY_IMAGE = "quay.io/microcks/contract-testing-demo:01";
+    private static readonly string GOOD_PASTRY_IMAGE = "quay.io/microcks/contract-testing-demo:02";
+
+    public INetwork Network { get; }
+    public MicrocksContainer MicrocksContainer { get; }
+    public IContainer BadImpl { get; }
+    public IContainer GoodImpl { get; }
+
+    public MicrocksContractTestingFixture()
+    {
+        Network = new NetworkBuilder().Build();
+
+        MicrocksContainer = new MicrocksBuilder()
+            .WithNetwork(Network)
+            .Build();
+
+        BadImpl = new ContainerBuilder()
+            .WithImage(BAD_PASTRY_IMAGE)
+            .WithNetwork(Network)
+            .WithNetworkAliases("bad-impl")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(".*Example app listening on port 3001.*"))
+            .Build();
+
+        GoodImpl = new ContainerBuilder()
+            .WithImage(GOOD_PASTRY_IMAGE)
+            .WithNetwork(Network)
+            .WithNetworkAliases("good-impl")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(".*Example app listening on port 3002.*"))
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        MicrocksContainer.Started +=
+            (_, _) => MicrocksContainer.ImportAsMainArtifact("apipastries-openapi.yaml");
+
+        await Network.CreateAsync();
+        await MicrocksContainer.StartAsync();
+        await BadImpl.StartAsync();
+        await GoodImpl.StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Dispose of the containers in reverse order of creation
+        await MicrocksContainer.DisposeAsync();
+        await BadImpl.DisposeAsync();
+        await GoodImpl.DisposeAsync();
+        await Network.DisposeAsync();
+    }
+
+}

--- a/tests/Microcks.Testcontainers.Tests/Fixtures/MicrocksTestCollection.cs
+++ b/tests/Microcks.Testcontainers.Tests/Fixtures/MicrocksTestCollection.cs
@@ -1,0 +1,26 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+namespace Microcks.Testcontainers.Tests.Fixtures;
+
+[CollectionDefinition("MicrocksTests")]
+public class MicrocksTestCollection : ICollectionFixture<MicrocksContractTestingFixture>
+{
+    // This class has no code, and is never created. Its purpose is simply
+    // to be the place to apply [CollectionDefinition] and all the
+    // ICollectionFixture<> interfaces.
+}


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Reuse Testcontainers across tests to drastically reduce test runtime and flakiness by switching per-test lifecycle to shared fixtures / collections where appropriate.

Replace per-test container creation/destruction with IClassFixture<T> (or test collections when multiple test classes must share resources), move fixtures close to tests (inner class where requested), and update tests to use the fixtures.

Sample: 3 tests KAFKA + Microcks, Before: 69 seconds, After: 44 seconds.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [x] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [x] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`

#158 