### PR TITLE
chore: new dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,28 +16,13 @@ updates:
       day: "sunday"
     open-pull-requests-limit: 3
     rebase-strategy: disabled
-    groups:
-      microsoft-sbom:
-        patterns: ['Microsoft.Sbom.Targets']
-      Microsoft.NET.Test.Sdk:
-        patterns: ['Microsoft.NET.Test.Sdk']
-      coverlet.collector:
-        patterns: ['coverlet.collector']
       testcontainers:
         patterns: [ 'Testcontainers', 'Testcontainers.*']
       microsoft:
         patterns: [Microsoft.*, System.*]
-      xunit:
-        patterns: [xunit.*]
-      # Grouping for Testcontainers
-      kafka:
-        patterns: ['Confluent.Kafka']
-      RabbitMQ.Client:
-        patterns: ['RabbitMQ.Client']
-      RestAssured.Net:
-        patterns: ['RestAssured.Net']
-      all-dependencies:
-        patterns: ['*']
+        exclude-patterns:
+         - Microsoft.Sbom.Targets
+         - Microsoft.NET.Test.Sdk
 
 # Github Actions updates
   - package-ecosystem: github-actions


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Keeps Dependabot PRs smaller and more focused for Microsoft and testcontainers families.

Excludes SBOM and Test SDK packages from the microsoft group so they can be handled separately.

Removing other groups reduces grouping noise and troubleshoot.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [x] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [x] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
