### PR TITLE
fix: preserve builder state across clone/merge

### DIFF
--- a/src/Microcks.Testcontainers/MicrocksAsyncMinionBuilder.cs
+++ b/src/Microcks.Testcontainers/MicrocksAsyncMinionBuilder.cs
@@ -33,7 +33,6 @@ public sealed class MicrocksAsyncMinionBuilder
 
     private const string MicrocksAsyncMinionFullImageName = "quay.io/microcks/microcks-uber-async-minion";
 
-    private readonly HashSet<string> _extraProtocols = [];
     private readonly INetwork _network;
 
     /// <inheritdoc />
@@ -64,6 +63,14 @@ public sealed class MicrocksAsyncMinionBuilder
     public override MicrocksAsyncMinionContainer Build()
     {
         Validate();
+
+        var protocols = DockerResourceConfiguration.ExtraProtocols;
+        if (protocols != null && protocols.Any())
+        {
+            var asyncProtocols = "," + string.Join(",", protocols.Distinct());
+            return new MicrocksAsyncMinionContainer(
+                WithEnvironment("ASYNC_PROTOCOLS", asyncProtocols).DockerResourceConfiguration);
+        }
 
         return new MicrocksAsyncMinionContainer(DockerResourceConfiguration);
     }
@@ -106,14 +113,8 @@ public sealed class MicrocksAsyncMinionBuilder
     /// <returns>The updated MicrocksAsyncMinionBuilder instance.</returns>
     public MicrocksAsyncMinionBuilder WithKafkaConnection(KafkaConnection kafkaConnection)
     {
-        _extraProtocols.Add("KAFKA");
-        var environments = new Dictionary<string, string>
-        {
-            { "ASYNC_PROTOCOLS", $",{string.Join(",", _extraProtocols)}" },
-            { "KAFKA_BOOTSTRAP_SERVER", kafkaConnection.BootstrapServers },
-        };
-
-        return Merge(DockerResourceConfiguration, new MicrocksAsyncMinionConfiguration(new ContainerConfiguration(environments: environments)));
+        return Merge(DockerResourceConfiguration, new MicrocksAsyncMinionConfiguration(extraProtocols: new[] { "KAFKA" }))
+            .WithEnvironment("KAFKA_BOOTSTRAP_SERVER", kafkaConnection.BootstrapServers);
     }
 
     /// <summary>
@@ -123,16 +124,10 @@ public sealed class MicrocksAsyncMinionBuilder
     /// <returns>The updated MicrocksAsyncMinionBuilder instance.</returns>
     public MicrocksAsyncMinionBuilder WithAmqpConnection(GenericConnection amqpConnection)
     {
-        _extraProtocols.Add("AMQP");
-        var environments = new Dictionary<string, string>
-        {
-            { "ASYNC_PROTOCOLS", $",{string.Join(",", _extraProtocols)}" },
-            { "AMQP_SERVER", amqpConnection.Url },
-            { "AMQP_USERNAME", amqpConnection.Username },
-            { "AMQP_PASSWORD", amqpConnection.Password },
-        };
-
-        return Merge(DockerResourceConfiguration, new MicrocksAsyncMinionConfiguration(new ContainerConfiguration(environments: environments)));
+        return Merge(DockerResourceConfiguration, new MicrocksAsyncMinionConfiguration(extraProtocols: new[] { "AMQP" }))
+            .WithEnvironment("AMQP_SERVER", amqpConnection.Url)
+            .WithEnvironment("AMQP_USERNAME", amqpConnection.Username)
+            .WithEnvironment("AMQP_PASSWORD", amqpConnection.Password);
     }
 
 

--- a/src/Microcks.Testcontainers/MicrocksAsyncMinionConfiguration.cs
+++ b/src/Microcks.Testcontainers/MicrocksAsyncMinionConfiguration.cs
@@ -23,9 +23,10 @@ public sealed class MicrocksAsyncMinionConfiguration : ContainerConfiguration
     /// <summary>
     /// Initializes a new instance of the <see cref="MicrocksAsyncMinionConfiguration" /> class.
     /// </summary>
-    /// <param name="config">The Microcks config.</param>
-    public MicrocksAsyncMinionConfiguration(object config = null)
+    /// <param name="extraProtocols">The extra async protocols (e.g. KAFKA, AMQP) to enable.</param>
+    public MicrocksAsyncMinionConfiguration(IEnumerable<string> extraProtocols = null)
     {
+        ExtraProtocols = extraProtocols;
     }
 
     /// <summary>
@@ -63,5 +64,11 @@ public sealed class MicrocksAsyncMinionConfiguration : ContainerConfiguration
     public MicrocksAsyncMinionConfiguration(MicrocksAsyncMinionConfiguration oldValue, MicrocksAsyncMinionConfiguration newValue)
         : base(oldValue, newValue)
     {
+        ExtraProtocols = BuildConfiguration.Combine(oldValue.ExtraProtocols, newValue.ExtraProtocols);
     }
+
+    /// <summary>
+    /// Gets the extra async protocols (e.g. KAFKA, AMQP) to enable on the async minion.
+    /// </summary>
+    public IEnumerable<string> ExtraProtocols { get; }
 }

--- a/src/Microcks.Testcontainers/MicrocksBuilder.cs
+++ b/src/Microcks.Testcontainers/MicrocksBuilder.cs
@@ -43,23 +43,15 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
     /// </summary>
     public const ushort MicrocksGrpcPort = 9090;
 
-    private List<string> _snapshots;
-
-    private List<string> _mainArtifacts;
-    private List<string> _secondaryArtifacts;
-    private List<RemoteArtifact> _mainRemoteArtifacts;
-    private List<RemoteArtifact> _secondaryRemoteArtifacts;
-
-    private List<Model.Secret> _secrets;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="MicrocksBuilder" /> class.
     /// </summary>
     /// <param name="image">The Docker image to use.</param>
-    public MicrocksBuilder(string image) 
-        : this()
+    public MicrocksBuilder(string image)
+        : this(new MicrocksConfiguration())
     {
         _microcksImage = image;
+        DockerResourceConfiguration = Init().DockerResourceConfiguration;
     }
 
     /// <summary>
@@ -97,36 +89,54 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
 
     private void ContainerStarted(MicrocksContainer container)
     {
+        var configuration = DockerResourceConfiguration;
+
         // Load snapshots before anything else.
-        if (_snapshots != null && _snapshots.Any())
+        if (configuration.Snapshots != null && configuration.Snapshots.Any())
         {
-            _snapshots.ForEach(snapshot => container.ImportSnapshotAsync(snapshot).GetAwaiter().GetResult());
+            foreach (var snapshot in configuration.Snapshots)
+            {
+                container.ImportSnapshotAsync(snapshot).GetAwaiter().GetResult();
+            }
         }
         // Load secrets before remote artifacts as they may be needed for authentication.
-        if (_secrets != null && _secrets.Any())
+        if (configuration.Secrets != null && configuration.Secrets.Any())
         {
-            _secrets.ForEach(secret => container.CreateSecretAsync(secret).GetAwaiter().GetResult());
+            foreach (var secret in configuration.Secrets)
+            {
+                container.CreateSecretAsync(secret).GetAwaiter().GetResult();
+            }
         }
         // Load remote artifacts before local ones.
-        if (_mainRemoteArtifacts != null && _mainRemoteArtifacts.Any())
+        if (configuration.MainRemoteArtifacts != null && configuration.MainRemoteArtifacts.Any())
         {
-            _mainRemoteArtifacts.ForEach(remoteArtifact =>
-                container.DownloadArtifactAsync(remoteArtifact, main: true).GetAwaiter().GetResult());
+            foreach (var remoteArtifact in configuration.MainRemoteArtifacts)
+            {
+                container.DownloadArtifactAsync(remoteArtifact, main: true).GetAwaiter().GetResult();
+            }
         }
-        if (_secondaryRemoteArtifacts != null && _secondaryRemoteArtifacts.Any())
+        if (configuration.SecondaryRemoteArtifacts != null && configuration.SecondaryRemoteArtifacts.Any())
         {
-            _secondaryRemoteArtifacts.ForEach(remoteArtifact =>
-                container.DownloadArtifactAsync(remoteArtifact, main: false).GetAwaiter().GetResult());
+            foreach (var remoteArtifact in configuration.SecondaryRemoteArtifacts)
+            {
+                container.DownloadArtifactAsync(remoteArtifact, main: false).GetAwaiter().GetResult();
+            }
         }
 
-        if (_mainArtifacts != null && _mainArtifacts.Any())
+        if (configuration.MainArtifacts != null && configuration.MainArtifacts.Any())
         {
-            _mainArtifacts.ForEach(container.ImportAsMainArtifact);
+            foreach (var artifact in configuration.MainArtifacts)
+            {
+                container.ImportAsMainArtifact(artifact);
+            }
         }
 
-        if (_secondaryArtifacts != null && _secondaryArtifacts.Any())
+        if (configuration.SecondaryArtifacts != null && configuration.SecondaryArtifacts.Any())
         {
-            _secondaryArtifacts.ForEach(container.ImportAsSecondaryArtifact);
+            foreach (var artifact in configuration.SecondaryArtifacts)
+            {
+                container.ImportAsSecondaryArtifact(artifact);
+            }
         }
     }
 
@@ -166,16 +176,7 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
     /// <returns></returns>
     public MicrocksBuilder WithSnapshots(params string[] snapshots)
     {
-        if (_snapshots == null)
-        {
-            _snapshots = new List<string>(snapshots);
-        }
-        else
-        {
-            _snapshots.AddRange(snapshots);
-        }
-
-        return this;
+        return Merge(DockerResourceConfiguration, new MicrocksConfiguration(snapshots: snapshots));
     }
 
     /// <summary>
@@ -185,13 +186,7 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
     /// <returns></returns>
     public MicrocksBuilder WithMainRemoteArtifacts(params RemoteArtifact[] mainRemoteArtifacts)
     {
-        if (_mainRemoteArtifacts == null)
-        {
-            _mainRemoteArtifacts = new List<RemoteArtifact>(mainRemoteArtifacts.Length);
-        }
-        _mainRemoteArtifacts.AddRange(mainRemoteArtifacts);
-
-        return this;
+        return Merge(DockerResourceConfiguration, new MicrocksConfiguration(mainRemoteArtifacts: mainRemoteArtifacts));
     }
 
     /// <summary>
@@ -201,13 +196,8 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
     /// <returns></returns>
     public MicrocksBuilder WithMainRemoteArtifacts(params string[] mainRemoteArtifacts)
     {
-        if (_mainRemoteArtifacts == null)
-        {
-            _mainRemoteArtifacts = new List<RemoteArtifact>(mainRemoteArtifacts.Length);
-        }
-        _mainRemoteArtifacts.AddRange(mainRemoteArtifacts.Select(url => new RemoteArtifact(url, null)));
-
-        return this;
+        return Merge(DockerResourceConfiguration, new MicrocksConfiguration(
+            mainRemoteArtifacts: mainRemoteArtifacts.Select(url => new RemoteArtifact(url, null))));
     }
 
     /// <summary>
@@ -217,16 +207,7 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
     /// <returns></returns>
     public MicrocksBuilder WithMainArtifacts(params string[] mainArtifacts)
     {
-        if (_mainArtifacts == null)
-        {
-            _mainArtifacts = new List<string>(mainArtifacts);
-        }
-        else
-        {
-            _mainArtifacts.AddRange(mainArtifacts);
-        }
-
-        return this;
+        return Merge(DockerResourceConfiguration, new MicrocksConfiguration(mainArtifacts: mainArtifacts));
     }
 
     /// <summary>
@@ -236,13 +217,7 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
     /// <returns></returns>
     public MicrocksBuilder WithSecondaryRemoteArtifacts(params RemoteArtifact[] secondaryRemoteArtifacts)
     {
-        if (_secondaryRemoteArtifacts == null)
-        {
-            _secondaryRemoteArtifacts = new List<RemoteArtifact>(secondaryRemoteArtifacts.Length);
-        }
-        _secondaryRemoteArtifacts.AddRange(secondaryRemoteArtifacts);
-
-        return this;
+        return Merge(DockerResourceConfiguration, new MicrocksConfiguration(secondaryRemoteArtifacts: secondaryRemoteArtifacts));
     }
 
     /// <summary>
@@ -252,16 +227,7 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
     /// <returns></returns>
     public MicrocksBuilder WithSecondaryArtifacts(params string[] secondaryArtifacts)
     {
-        if (_secondaryArtifacts == null)
-        {
-            _secondaryArtifacts = new List<string>(secondaryArtifacts);
-        }
-        else
-        {
-            _secondaryArtifacts.AddRange(secondaryArtifacts);
-        }
-
-        return this;
+        return Merge(DockerResourceConfiguration, new MicrocksConfiguration(secondaryArtifacts: secondaryArtifacts));
     }
 
     /// <summary>
@@ -271,16 +237,7 @@ public sealed class MicrocksBuilder : ContainerBuilder<MicrocksBuilder, Microcks
     /// <returns></returns>
     public MicrocksBuilder WithSecrets(params Model.Secret[] secrets)
     {
-        if (_secrets == null)
-        {
-            _secrets = new List<Model.Secret>(secrets);
-        }
-        else
-        {
-            _secrets.AddRange(secrets);
-        }
-
-        return this;
+        return Merge(DockerResourceConfiguration, new MicrocksConfiguration(secrets: secrets));
     }
 
     /// <summary>

--- a/src/Microcks.Testcontainers/MicrocksConfiguration.cs
+++ b/src/Microcks.Testcontainers/MicrocksConfiguration.cs
@@ -23,9 +23,26 @@ public sealed class MicrocksConfiguration : ContainerConfiguration
     /// <summary>
     /// Initializes a new instance of the <see cref="MicrocksConfiguration" /> class.
     /// </summary>
-    /// <param name="config">The Microcks config.</param>
-    public MicrocksConfiguration(object config = null)
+    /// <param name="snapshots">The snapshots to import.</param>
+    /// <param name="mainArtifacts">The main artifacts to import.</param>
+    /// <param name="secondaryArtifacts">The secondary artifacts to import.</param>
+    /// <param name="mainRemoteArtifacts">The main remote artifacts to download.</param>
+    /// <param name="secondaryRemoteArtifacts">The secondary remote artifacts to download.</param>
+    /// <param name="secrets">The secrets to create.</param>
+    public MicrocksConfiguration(
+        IEnumerable<string> snapshots = null,
+        IEnumerable<string> mainArtifacts = null,
+        IEnumerable<string> secondaryArtifacts = null,
+        IEnumerable<RemoteArtifact> mainRemoteArtifacts = null,
+        IEnumerable<RemoteArtifact> secondaryRemoteArtifacts = null,
+        IEnumerable<Model.Secret> secrets = null)
     {
+        Snapshots = snapshots;
+        MainArtifacts = mainArtifacts;
+        SecondaryArtifacts = secondaryArtifacts;
+        MainRemoteArtifacts = mainRemoteArtifacts;
+        SecondaryRemoteArtifacts = secondaryRemoteArtifacts;
+        Secrets = secrets;
     }
 
     /// <summary>
@@ -63,5 +80,41 @@ public sealed class MicrocksConfiguration : ContainerConfiguration
     public MicrocksConfiguration(MicrocksConfiguration oldValue, MicrocksConfiguration newValue)
         : base(oldValue, newValue)
     {
+        Snapshots = BuildConfiguration.Combine(oldValue.Snapshots, newValue.Snapshots);
+        MainArtifacts = BuildConfiguration.Combine(oldValue.MainArtifacts, newValue.MainArtifacts);
+        SecondaryArtifacts = BuildConfiguration.Combine(oldValue.SecondaryArtifacts, newValue.SecondaryArtifacts);
+        MainRemoteArtifacts = BuildConfiguration.Combine(oldValue.MainRemoteArtifacts, newValue.MainRemoteArtifacts);
+        SecondaryRemoteArtifacts = BuildConfiguration.Combine(oldValue.SecondaryRemoteArtifacts, newValue.SecondaryRemoteArtifacts);
+        Secrets = BuildConfiguration.Combine(oldValue.Secrets, newValue.Secrets);
     }
+
+    /// <summary>
+    /// Gets the snapshots to import into the Microcks container.
+    /// </summary>
+    public IEnumerable<string> Snapshots { get; }
+
+    /// <summary>
+    /// Gets the main artifacts to import into the Microcks container.
+    /// </summary>
+    public IEnumerable<string> MainArtifacts { get; }
+
+    /// <summary>
+    /// Gets the secondary artifacts to import into the Microcks container.
+    /// </summary>
+    public IEnumerable<string> SecondaryArtifacts { get; }
+
+    /// <summary>
+    /// Gets the main remote artifacts to download into the Microcks container.
+    /// </summary>
+    public IEnumerable<RemoteArtifact> MainRemoteArtifacts { get; }
+
+    /// <summary>
+    /// Gets the secondary remote artifacts to download into the Microcks container.
+    /// </summary>
+    public IEnumerable<RemoteArtifact> SecondaryRemoteArtifacts { get; }
+
+    /// <summary>
+    /// Gets the secrets to create into the Microcks container.
+    /// </summary>
+    public IEnumerable<Model.Secret> Secrets { get; }
 }

--- a/src/Microcks.Testcontainers/MicrocksContainerEnsemble.cs
+++ b/src/Microcks.Testcontainers/MicrocksContainerEnsemble.cs
@@ -99,7 +99,7 @@ public class MicrocksContainerEnsemble : IAsyncDisposable, IArtifactAndSnapshotM
     /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns>
     public MicrocksContainerEnsemble WithMainArtifacts(params string[] mainArtifacts)
     {
-        this._microcksBuilder.WithMainArtifacts(mainArtifacts);
+        this._microcksBuilder = this._microcksBuilder.WithMainArtifacts(mainArtifacts);
         return this;
     }
 
@@ -110,7 +110,7 @@ public class MicrocksContainerEnsemble : IAsyncDisposable, IArtifactAndSnapshotM
     /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns>
     public MicrocksContainerEnsemble WithMainRemoteArtifacts(params string[] mainRemoteArtifacts)
     {
-        this._microcksBuilder.WithMainRemoteArtifacts(mainRemoteArtifacts);
+        this._microcksBuilder = this._microcksBuilder.WithMainRemoteArtifacts(mainRemoteArtifacts);
         return this;
     }
 
@@ -121,7 +121,7 @@ public class MicrocksContainerEnsemble : IAsyncDisposable, IArtifactAndSnapshotM
     /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns>
     public MicrocksContainerEnsemble WithMainRemoteArtifacts(params RemoteArtifact[] mainRemoteArtifacts)
     {
-        this._microcksBuilder.WithMainRemoteArtifacts(mainRemoteArtifacts);
+        this._microcksBuilder = this._microcksBuilder.WithMainRemoteArtifacts(mainRemoteArtifacts);
         return this;
     }
 
@@ -132,7 +132,7 @@ public class MicrocksContainerEnsemble : IAsyncDisposable, IArtifactAndSnapshotM
     /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns>
     public MicrocksContainerEnsemble WithSecondaryArtifacts(params string[] secondaryArtifacts)
     {
-        this._microcksBuilder.WithSecondaryArtifacts(secondaryArtifacts);
+        this._microcksBuilder = this._microcksBuilder.WithSecondaryArtifacts(secondaryArtifacts);
         return this;
     }
 
@@ -143,7 +143,7 @@ public class MicrocksContainerEnsemble : IAsyncDisposable, IArtifactAndSnapshotM
     /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns>
     public MicrocksContainerEnsemble WithSecondaryRemoteArtifacts(params RemoteArtifact[] secondaryRemoteArtifacts)
     {
-        this._microcksBuilder.WithSecondaryRemoteArtifacts(secondaryRemoteArtifacts);
+        this._microcksBuilder = this._microcksBuilder.WithSecondaryRemoteArtifacts(secondaryRemoteArtifacts);
         return this;
     }
 
@@ -154,7 +154,7 @@ public class MicrocksContainerEnsemble : IAsyncDisposable, IArtifactAndSnapshotM
     /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns>
     public MicrocksContainerEnsemble WithSnapshots(params string[] snapshots)
     {
-        this._microcksBuilder.WithSnapshots(snapshots);
+        this._microcksBuilder = this._microcksBuilder.WithSnapshots(snapshots);
         return this;
     }
 
@@ -165,7 +165,7 @@ public class MicrocksContainerEnsemble : IAsyncDisposable, IArtifactAndSnapshotM
     /// <returns>The updated <see cref="MicrocksContainerEnsemble"/> instance.</returns>
     public MicrocksContainerEnsemble WithSecrets(params Model.Secret[] secrets)
     {
-        this._microcksBuilder.WithSecrets(secrets);
+        this._microcksBuilder = this._microcksBuilder.WithSecrets(secrets);
         return this;
     }
 

--- a/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncMinionProtocolsTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/Async/MicrocksAsyncMinionProtocolsTests.cs
@@ -1,0 +1,51 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+using System.Linq;
+
+namespace Microcks.Testcontainers.Tests.Async;
+
+/// <summary>
+/// Proves that the async protocols survive a builder clone/merge: combining
+/// two connections (e.g. Kafka then AMQP) must keep BOTH protocols instead of
+/// the later one overwriting the former.
+/// </summary>
+public sealed class MicrocksAsyncMinionProtocolsTests
+{
+    [Fact]
+    public void Merge_ShouldCombineExtraProtocolsFromBothConfigurations()
+    {
+        var kafka = new MicrocksAsyncMinionConfiguration(extraProtocols: new[] { "KAFKA" });
+        var amqp = new MicrocksAsyncMinionConfiguration(extraProtocols: new[] { "AMQP" });
+
+        var merged = new MicrocksAsyncMinionConfiguration(kafka, amqp);
+
+        Assert.Contains("KAFKA", merged.ExtraProtocols);
+        Assert.Contains("AMQP", merged.ExtraProtocols);
+    }
+
+    [Fact]
+    public void Merge_ShouldPreserveExistingProtocols_WhenNewConfigurationHasNone()
+    {
+        var kafka = new MicrocksAsyncMinionConfiguration(extraProtocols: new[] { "KAFKA" });
+        var withoutProtocols = new MicrocksAsyncMinionConfiguration();
+
+        var merged = new MicrocksAsyncMinionConfiguration(kafka, withoutProtocols);
+
+        Assert.Equal(new[] { "KAFKA" }, merged.ExtraProtocols.ToArray());
+    }
+}

--- a/tests/Microcks.Testcontainers.Tests/MicrocksBuilderImageTests.cs
+++ b/tests/Microcks.Testcontainers.Tests/MicrocksBuilderImageTests.cs
@@ -1,0 +1,63 @@
+//
+// Copyright The Microcks Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+namespace Microcks.Testcontainers.Tests;
+
+public sealed class MicrocksBuilderImageTests
+{
+    private const string CustomImage = "quay.io/microcks/microcks-uber:1.14.0";
+
+    [Fact]
+    public void Build_WithCustomImage_ShouldUseProvidedImage()
+    {
+        var container = new MicrocksBuilder(CustomImage).Build();
+
+        Assert.Equal(CustomImage, container.Image.FullName);
+    }
+
+    [Fact]
+    public void Build_WithCustomImageAndAdditionalConfiguration_ShouldKeepProvidedImage()
+    {
+        var builder = new MicrocksBuilder(CustomImage)
+            .WithEnvironment("FOO", "BAR");
+
+        var container = builder.Build();
+
+        Assert.Equal(CustomImage, container.Image.FullName);
+    }
+
+    [Fact]
+    public async Task Build_WithCustomImageAcrossMultipleSteps_ShouldKeepProvidedImageAndEnvironment()
+    {
+        var builder = new MicrocksBuilder(CustomImage)
+            .WithMainArtifacts("apipastries-openapi.yaml");
+
+        builder = builder.WithEnvironment("FOO", "BAR");
+
+        await using var container = builder.Build();
+        await container.StartAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(CustomImage, container.Image.FullName);
+
+        using var dockerClient = new Docker.DotNet.DockerClientConfiguration().CreateClient();
+        var inspect = await dockerClient.Containers.InspectContainerAsync(
+            container.Id,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains("FOO=BAR", inspect.Config.Env);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Proposed Changes

This PR fixes immutable builder state loss when clone/merge happens in Microcks Testcontainers.

- Preserve custom image handling in `MicrocksBuilder` constructor/clone path.
- Preserve artifacts, snapshots, remote artifacts, and secrets through merge in `MicrocksConfiguration`.
- Reassign immutable builder returns in `MicrocksContainerEnsemble` wrapper methods.
- Preserve combined async protocols (`KAFKA`, `AMQP`) through merge in async minion configuration.
- Add regression tests for image handling and async protocol merge behavior.

Closes #256
Closes #257

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `dotnet test` and ensure you have test coverage for the lines you are introducing
- [ ] run `dotnet husky run` and fix any issues that you have introduced

### Reviewer

- [ ] Label as either `feature`, `fix`, `documentation`, `enhancement`, `maintenance` or `breaking`
